### PR TITLE
Back button fix

### DIFF
--- a/app/js/services.js
+++ b/app/js/services.js
@@ -423,7 +423,7 @@ angular.module('myApp.services', [])
   NotificationsManager.start();
 
   function getDialogs (offset, limit) {
-    if (dialogsStorage.count !== null && dialogsStorage.dialogs.length >= offset + limit) {
+    if (dialogsStorage.count !== null && dialogsStorage.dialogs.length <= offset + limit) {
       return $q.when({
         count: dialogsStorage.count,
         dialogs: dialogsStorage.dialogs.slice(offset, offset + limit)


### PR DESCRIPTION
Обсуждение ошибки началось здесь - https://vk.com/topic-61543295_29461414?post=42

Было установлено что происходит ререндеринг [партиала](https://github.com/zhukov/webogram/blob/master/app/partials/im.html#L7) при нажатии кнопки Назад, который влечет за собой вызов контроллера AppImDialogsController где мы можем видеть [вызов](https://github.com/zhukov/webogram/blob/master/app/js/controllers.js#L199) сервиса AppMessagesManager и его метода getDialogs который должен вернуть нам [диалоги(dialogsResult.dialogs)](https://github.com/zhukov/webogram/blob/master/app/js/controllers.js#L203-L206) . В сервисе мы [видим](https://github.com/zhukov/webogram/blob/master/app/js/services.js#L426) опечатку, которая не позволяет получить данные уже сохраненные в dialogsStorage, а вместо этого выполняется очередная подгрузка уже существующих диалогов(контактов).
