### PR TITLE
Do not use Google Chrome specific error messages

### DIFF
--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -100,7 +100,7 @@ angular.module('myApp.controllers', [])
             break;
 
           default:
-            ErrorService.showSimpleError('Unknown error occured', 'Please check your internet connection or install the latest version of Google Chrome browser.');
+            ErrorService.showSimpleError('Unknown error occured', 'Please check your internet connection or update your Software.');
         }
       });
     }


### PR DESCRIPTION
It would not make sense while running in Firefox/FirefoxOS.
