### PR TITLE
Firefox fix to #74 - Paste from clipboard in Firefox

### DIFF
--- a/app/js/directives.js
+++ b/app/js/directives.js
@@ -438,6 +438,7 @@ angular.module('myApp.directives', ['myApp.filters'])
 
       $('body').on('dragenter dragleave dragover drop', onDragDropEvent);
       $(document).on('paste', onPasteEvent);
+      $('.emoji-wysiwyg-editor.form-control').bind('DOMNodeInserted', onPastedImageEvent);
 
       scope.$on('ui_peer_change', focusField);
       scope.$on('ui_history_focus', focusField);
@@ -450,6 +451,7 @@ angular.module('myApp.directives', ['myApp.filters'])
       scope.$on('$destroy', function cleanup() {
         $('body').off('dragenter dragleave dragover drop', onDragDropEvent);
         $(document).off('paste', onPasteEvent);
+        $('.emoji-wysiwyg-editor.form-control').unbind('DOMNodeInserted', onPastedImageEvent);
       });
 
       focusField();
@@ -459,6 +461,31 @@ angular.module('myApp.directives', ['myApp.filters'])
           editorElement.focus();
         });
       }
+
+      function onPastedImageEvent (e) {
+        var element = e && e.target;
+        var src;
+        if (element && (src = element.src) && src.indexOf('data') === 0) {
+          element.parentNode.removeChild(element);
+          src = src.substr(5).split(';');
+          var contentType = src[0];
+          var base64 = atob(src[1].split(',')[1]);
+          var array = new Uint8Array(base64.length);
+
+          for (var i = 0; i < base64.length; i++) {
+            array[i] = base64.charCodeAt(i);
+          }
+
+          var blob = new Blob([array], {type: contentType});
+
+          if (safeConfirm('Are you sure to send file(s) from clipboard?')) {
+            scope.$apply(function () {
+              scope.draftMessage.files = [blob];
+              scope.draftMessage.isMedia = true;
+            });
+          }
+        }
+      };
 
       function onPasteEvent (e) {
         var cData = (e.originalEvent || e).clipboardData,


### PR DESCRIPTION
Firefox fix to #74
It can even paste copied image files, not only screenshots, I didn't see that coming.
It doesn't seem possible to paste more than a file at a time nor non-images, at least not the same way I grabbed pasted images.
