### PR TITLE
fixed appCache.update error.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -31,7 +31,11 @@
         scheduleUpdate = function (delay) {
           clearTimeout(updateTimeout);
           updateTimeout = setTimeout(function () {
-            appCache.update();
+            try {
+              appCache.update();
+            } catch (ex) {
+              console.log('appCache.update: ' + ex);
+            }
           }, delay || 300000);
         },
         attach = function () {


### PR DESCRIPTION
webkit-app (v0.9.2) Error Message:
InvalidStateError: Failed to execute 'update' on 'ApplicationCache': there is no application cache to update.
