### PR TITLE
Launch path needs a full path from the host root directory.

### DIFF
--- a/app/manifest.webapp
+++ b/app/manifest.webapp
@@ -2,7 +2,7 @@
   "name": "Webogram",
   "description": "Webogram – UNOFFICIAL Telegram Web App.\nMore info & source code here: https://github.com/zhukov/webogram",
   "version": "0.1.1",
-  "launch_path": "/index.html",
+  "launch_path": "/webogram/index.html",
   "developer": {
     "name": "Igor Zhukov",
     "url": "https://github.com/zhukov"


### PR DESCRIPTION
I think this will fix the following issues when trying to validate the manifest for Firefox OS

https://marketplace.firefox.com/developers/upload/0f74c3259e904cdcab3c726c13b54a55

contributes to #300 
