### PR TITLE
UI messaging for slow key generation

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -780,6 +780,11 @@ a.tg_radio_on:hover i.icon-radio {
   margin: 15px 0 30px;
   font-size: 13px;
 }
+.login_form_messaging {
+  color: #959595;
+  font-size: 13px;
+  margin-top: 10px;
+}
 
 .login_country_selector {
   cursor: pointer;

--- a/app/partials/login.html
+++ b/app/partials/login.html
@@ -24,6 +24,7 @@
       <span ng-switch-when="true">Generating keys<span my-loading-dots></span></span>
       <span ng-switch-default>Next</span>
     </button>
+    <div class="login_form_messaging" ng-show="progress.enabled">Key generation will only happen once, it could take several minutes on slower devices, please be patient.</div>
   </form>
 
   <form name="myLoginForm" ng-if="credentials.phone_code_hash &amp;&amp; !credentials.phone_code_valid" ng-submit="logIn()">


### PR DESCRIPTION
Added messaging to the login form to indicate that key generation may take a long time on slow devices. This does not fix the slow key generation but does adjust expectations so it should not be frustrating. Fix #40.
