### PR TITLE
Fix Firefox OS detection. Fix #435

### DIFF
--- a/app/js/lib/config.js
+++ b/app/js/lib/config.js
@@ -36,7 +36,7 @@ Config.Navigator = {
   osX:  (navigator.platform || '').toLowerCase().indexOf('mac') != -1 ||
         (navigator.userAgent || '').toLowerCase().indexOf('mac') != -1,
   retina: window.devicePixelRatio > 1,
-  ffos: navigator.userAgent.match(/mobi.+Gecko/i),
+  ffos: navigator.userAgent.search(/mobi.+Gecko/i) != -1,
   touch: screen.width <= 768,
   mobile: screen.width < 480
 };


### PR DESCRIPTION
Fixes the Firefox OS detection in `Config` to return a boolean.
