### PR TITLE
Youtube links 522

### DIFF
--- a/app/js/services.js
+++ b/app/js/services.js
@@ -3321,7 +3321,7 @@ angular.module('myApp.services', ['myApp.i18n'])
     // console.log(4, text, html);
     if (!options.noLinks) {
       var youtubeMatches = text.match(youtubeRegex),
-          videoID = youtubeMatches && youtubeMatches[1];
+          videoID = youtubeMatches && youtubeMatches[youtubeMatches.length-1];
 
       if (videoID) {
         var tag = Config.Modes.chrome_packed ? 'webview' : 'iframe';


### PR DESCRIPTION
Youtube links with "/?#" or "#" don't detect. So:

1) Edited regular expression to add "/?#" and "#"

2) "youtubeMatches" returns 3 values instead 2, and the videoID is always the last element

Greetings.
