### PR TITLE
Correct autonym of Dutch language

### DIFF
--- a/app/js/lib/config.js
+++ b/app/js/lib/config.js
@@ -62,7 +62,7 @@ Config.I18n = {
     'es-es': 'Español',
     'it-it': 'Italiano',
     'ru-ru': 'Русский',
-    'nl-nl': 'Dutch',
+    'nl-nl': 'Nederlands',
     'pt-br': 'Português (Brazil)'
   },
   aliases: {


### PR DESCRIPTION
"Dutch" to "Nederlands"
https://en.wikipedia.org/wiki/Dutch_language
