### PR TITLE
Disallow bad Soundcloud directory names

### DIFF
--- a/app/js/services.js
+++ b/app/js/services.js
@@ -3317,7 +3317,7 @@ angular.module('myApp.services', ['myApp.i18n', 'izhukov.utils'])
     }
     else if (embedUrlMatches = text.match(soundcloudRegex)) {
       var badFolders = 'explore,upload,pages,terms-of-use,mobile,jobs,imprint'.split(',');
-      if (badFolders.indexOf(embedUrlMatches[1]) != -1) {
+      if (badFolders.indexOf(embedUrlMatches[1]) == -1) {
         return ['soundcloud', embedUrlMatches[0]];
       }
     }


### PR DESCRIPTION
The current Soundcloud embed code will only embed URLs which are inside bad folders.  This PR should properly fix #574.
