### PR TITLE
Demo: "fix last message" feature

### DIFF
--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -780,6 +780,7 @@ angular.module('myApp.controllers', ['myApp.i18n'])
     });
 
 
+
     $scope.$on('history_return_recent', returnToRecent);
 
     var peerID,
@@ -1357,6 +1358,30 @@ angular.module('myApp.controllers', ['myApp.i18n'])
       }
     });
 
+
+    $scope.fixLastMessage = function() {
+      var myMessages = []; // replace with filter
+      angular.forEach(historiesQueueFind(peerID).messages, function (m) {
+        if (m.out) {
+          myMessages.push(m);
+        }
+      });
+      if (myMessages.length > 0) {
+        var lastMessage = myMessages[myMessages.length - 1];
+        $('form').scope().$deleteMessageId = lastMessage.id;
+        $('.emoji-wysiwyg-editor').text(lastMessage.message);
+        setTimeout(function () { //workaround for emojiarea restoring selection
+            var range = document.createRange();
+            range.setStart($('.emoji-wysiwyg-editor')[0].firstChild, lastMessage.message.length);
+            range.collapse(true);
+            var sel = window.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(range);
+        }, 10);
+
+      }
+    }
+
     $scope.$on('history_need_less', showLessHistory);
     $scope.$on('history_need_more', showMoreHistory);
 
@@ -1383,38 +1408,50 @@ angular.module('myApp.controllers', ['myApp.i18n'])
     $scope.$watch('draftMessage.files', onFilesSelected);
 
     function sendMessage (e) {
+
       $scope.$broadcast('ui_message_before_send');
 
-      $timeout(function () {
-        var text = $scope.draftMessage.text;
+      if ($scope.$deleteMessageId) {
+        AppMessagesManager.deleteMessages([$scope.$deleteMessageId]).then(function (e) {
+          $scope.$deleteMessageId = null;
+          _sendMessage();
+        });
+      } else {
+        _sendMessage();
+      }
 
-        if (angular.isString(text) && text.length > 0) {
-          text = text.replace(/:([a-z0-9\-\+\*_]+?):/gi, function (all, name) {
-            var utfChar = $.emojiarea.reverseIcons[name];
-            if (utfChar !== undefined) {
-              return utfChar;
-            }
-            return all;
-          });
+      function _sendMessage() {
+        $timeout(function () {
+          var text = $scope.draftMessage.text;
 
-          var timeout = 0;
-          do {
+          if (angular.isString(text) && text.length > 0) {
+            text = text.replace(/:([a-z0-9\-\+\*_]+?):/gi, function (all, name) {
+              var utfChar = $.emojiarea.reverseIcons[name];
+              if (utfChar !== undefined) {
+                return utfChar;
+              }
+              return all;
+            });
 
-            (function (peerID, curText, curTimeout) {
-              setTimeout(function () {
-                AppMessagesManager.sendText(peerID, curText);
-              }, curTimeout)
-            })($scope.curDialog.peerID, text.substr(0, 4096), timeout);
+            var timeout = 0;
+            do {
 
-            text = text.substr(4096);
-            timeout += 100;
+              (function (peerID, curText, curTimeout) {
+                setTimeout(function () {
+                  AppMessagesManager.sendText(peerID, curText);
+                }, curTimeout)
+              })($scope.curDialog.peerID, text.substr(0, 4096), timeout);
 
-          } while (text.length);
-        }
+              text = text.substr(4096);
+              timeout += 100;
 
-        resetDraft();
-        $scope.$broadcast('ui_message_send');
-      });
+            } while (text.length);
+          }
+
+          resetDraft();
+          $scope.$broadcast('ui_message_send');
+        });
+      }
 
       return cancelEvent(e);
     }

--- a/app/js/directives.js
+++ b/app/js/directives.js
@@ -482,6 +482,11 @@ angular.module('myApp.directives', ['myApp.filters'])
           skip = true;
         }
         if (next || prev) {
+          // restore previous message to fix typo
+          if (prev && document.activeElement.className.indexOf('emoji-wysiwyg-editor') > -1 && window.getSelection().baseOffset === 0) {
+            angular.element($('.im_history_col_wrap')).scope().fixLastMessage();
+          }
+
           if (!skip && (!searchFocused || e.metaKey)) {
             return true;
           }
@@ -1674,7 +1679,7 @@ angular.module('myApp.directives', ['myApp.filters'])
           realImageWidth = image.width;
           realImageHeight = image.height;
           clearInterval(checkSizesInt);
-          
+
           var defaultWh = calcImageInBox(image.width, image.height, fullWidth, fullHeight, true);
           var zoomedWh = {w: realImageWidth, h: realImageHeight};
           if (defaultWh.w >= zoomedWh.w && defaultWh.h >= zoomedWh.h) {


### PR DESCRIPTION
This PR is just a demonstration of interface. There is no issue created before, I'm sorry about that.
You can press "up arrow" key and fix message that you have previously sent. It helps to fix misspellings and typo mistakes. 
![gif](http://g.recordit.co/Tv2xr1bjxU.gif)
Unfortunately, right now it isn't working properly, because the Telegram API doesn't allow to delete messages from everybody's history, only from yours 
https://core.telegram.org/method/messages.deleteMessages
https://telegram.org/privacy#3-deleting-data
So I hope there is a way to discuss about changing `deleteMessages` behaviour with Telegram Developers. It could be a non-breaking new flag for deleting only the last message or server-side time checking. 