### PR TITLE
More contrast for selected emoticon. Fix #721

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -2142,8 +2142,8 @@ a.composer_emoji_btn:hover {
 }
 .composer_dropdown li a:hover,
 .composer_dropdown li a.composer_emoji_option_active {
-  color: #52719a;
-  background: #f2f6fa;
+  color: #ffffff;
+  background: #6490b1;
 }
 .composer_emoji_shortcut {
   display: inline-block;


### PR DESCRIPTION
p.s. What about top/bottom paddings in `.composer_dropdown` node? I think that padding is useless. Also `dropdown-menu` has similar paddings.

**Idea**
![idea](https://cloud.githubusercontent.com/assets/5507542/6418098/62056782-bec3-11e4-9b5c-5f3cd67fb79d.png)

**Exist**
![exist](https://cloud.githubusercontent.com/assets/5507542/6418102/6622f80c-bec3-11e4-8305-a07f4e497040.png)
