### PR TITLE
Update Dockerfile to work with gulp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM node
 ADD . /opt/webogram
 WORKDIR /opt/webogram
 
-RUN npm install
+RUN npm install -g gulp && npm install
 
 EXPOSE 8000
 
-CMD ["node", "server.js", "8000", "0.0.0.0"]
+CMD ["gulp", "watch"]


### PR DESCRIPTION
Apparently this is now the way to run the application and get all assets to be served correctly, only noticed this today after updating my local setup again.