### PR TITLE
Modal stack single option

### DIFF
--- a/app/js/services.js
+++ b/app/js/services.js
@@ -271,7 +271,8 @@ angular.module('myApp.services', ['myApp.i18n', 'izhukov.utils'])
       templateUrl: templateUrl('user_modal'),
       controller: 'UserModalController',
       scope: scope,
-      windowClass: 'user_modal_window mobile_modal'
+      windowClass: 'user_modal_window mobile_modal',
+      backdrop: 'single'
     });
   };
 

--- a/app/vendor/ui-bootstrap/ui-bootstrap-custom-tpls-0.12.0.js
+++ b/app/vendor/ui-bootstrap/ui-bootstrap-custom-tpls-0.12.0.js
@@ -787,6 +787,10 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         element.addClass(attrs.windowClass || '');
         scope.size = attrs.size;
 
+        $modalStack.registerObserverCallback(function(hiddenBySingle) {
+          scope.hiddenBySingle = hiddenBySingle || false;
+        });
+
         $timeout(function () {
           // trigger CSS transitions
           scope.animate = true;
@@ -835,6 +839,25 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
       var backdropDomEl, backdropScope;
       var openedWindows = $$stackedMap.createNew();
       var $modalStack = {};
+      var observerCallbacks = [];
+
+      function notifyObservers() {
+        angular.forEach(observerCallbacks, function(callback, index) {
+          var hasSingleParent = false,
+              opened = openedWindows.keys();
+
+          for (var i = 0; i < opened.length; i++) {
+            var item = openedWindows.get(opened[i]).value;
+
+            if (item.backdrop == 'single' && item.index > index) {
+              hasSingleParent = true;
+              break;
+            }
+          }
+
+          callback(hasSingleParent);
+        });
+      };
 
       function backdropIndex() {
         var topBackdropIndex = -1;
@@ -854,12 +877,14 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
       });
 
       function removeModalWindow(modalInstance) {
-
         var body = $document.find('body').eq(0);
         var modalWindow = openedWindows.get(modalInstance).value;
 
         //clean up the stack
         openedWindows.remove(modalInstance);
+
+        //clean up the observer
+        observerCallbacks.splice(modalWindow.index, 1);
 
         //remove window DOM element
         removeAfterAnimate(modalWindow.modalDomEl, modalWindow.modalScope, 0, function() {
@@ -879,6 +904,8 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
             });
             backdropDomEl = undefined;
             backdropScope = undefined;
+          } else {
+            notifyObservers();
           }
       }
 
@@ -928,8 +955,11 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         }
       });
 
-      $modalStack.open = function (modalInstance, modal) {
+      $modalStack.registerObserverCallback = function(callback){
+        observerCallbacks.push(callback);
+      };
 
+      $modalStack.open = function (modalInstance, modal) {
         openedWindows.add(modalInstance, {
           deferred: modal.deferred,
           modalScope: modal.scope,
@@ -949,19 +979,24 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
           body.append(backdropDomEl);
         }
 
-        var angularDomEl = angular.element('<div modal-window></div>');
+        var angularDomEl = angular.element('<div modal-window></div>'),
+            index = openedWindows.length() - 1;
+
         angularDomEl.attr({
           'template-url': modal.windowTemplateUrl,
           'window-class': modal.windowClass,
           'size': modal.size,
-          'index': openedWindows.length() - 1,
+          'index': index,
           'animate': 'animate'
         }).html(modal.content);
 
         var modalDomEl = $compile(angularDomEl)(modal.scope);
         openedWindows.top().value.modalDomEl = modalDomEl;
+        openedWindows.top().value.index = index;
         body.append(modalDomEl);
         body.addClass(OPENED_MODAL_CLASS);
+
+        notifyObservers();
       };
 
       $modalStack.close = function (modalInstance, result) {
@@ -1222,7 +1257,7 @@ angular.module("template/modal/backdrop.html", []).run(["$templateCache", functi
 
 angular.module("template/modal/window.html", []).run(["$templateCache", function($templateCache) {
   $templateCache.put("template/modal/window.html",
-    "<div tabindex=\"-1\" role=\"dialog\" class=\"modal fade\" ng-class=\"{in: animate}\" ng-style=\"{'z-index': 1050 + index*10, display: 'block'}\" ng-click=\"close($event)\">\n" +
+    "<div tabindex=\"-1\" role=\"dialog\" class=\"modal fade\" ng-class=\"{in: animate}\" ng-style=\"{'z-index': 1050 + index*10, display: hiddenBySingle ? 'none' : 'block'}\" ng-click=\"close($event)\">\n" +
     "  <div class=\"modal_close_wrap\" ng-click=\"close($event)\">\n" +
     "    <div class=\"modal_close\"></div>\n" +
     "  </div>\n" +


### PR DESCRIPTION
Ability to temporarily hide prev modal when open a new one.

To test how it works use steps:
1. Open any group chat
2. Open "Group info" modal
3. Click any person from ("Group info" is hidden now, because "Contact info" with backdrop = single)
4. Click "Share contact" link (member modal doesn't hidden, but "Group info" still hidden)
5. Close modal stack in sequence