### PR TITLE
Fixes #822 Mb to MB for accuracy.

### DIFF
--- a/app/js/filters.js
+++ b/app/js/filters.js
@@ -165,7 +165,7 @@ angular.module('myApp.filters', ['myApp.i18n'])
       } else {
         mbs = (Math.round(mbs * 10) / 10);
       }
-      return mbs + ' Mb';
+      return mbs + ' MB';
     }
   }])
 


### PR DESCRIPTION
Fixes #822 . As pointed out, MB would be more accurate, as the value shown is in megabytes (MB) while the symbol used is megabits(Mb).