### PR TITLE
Fix warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/zhukov/webogram.git"
   },
   "author": "zhukov",
-  "license": "GPL",
+  "license": "GPL-3.0",
   "bugs": {
     "url": "https://github.com/zhukov/webogram/issues"
   },


### PR DESCRIPTION
Fix warning during compiling:
```npm WARN package.json Telegram@0.4.7 license should be a valid SPDX license expression```

http://spdx.org/licenses/GPL-3.0.html