### PR TITLE
Fix #930: Preserve whitespaces in messages, like phone applications do

### DIFF
--- a/app/partials/desktop/im.html
+++ b/app/partials/desktop/im.html
@@ -188,7 +188,7 @@
                       <a class="composer_keyboard_btn" ng-show="historyState.replyKeyboard._ == 'replyKeyboardMarkup'" ng-mousedown="replyKeyboardToggle($event)" ng-class="!historyState.replyKeyboard.pFlags.hidden ? 'active' : ''"><i class="icon icon-keyboard"></i></a>
 
                       <div class="im_send_dropbox_wrap" my-i18n="im_photos_drop_text"></div>
-                      <textarea ng-model="draftMessage.text" class="form-control im_message_field no_outline" dir="auto"></textarea>
+                      <textarea ng-model="draftMessage.text" class="form-control im_message_field no_outline" dir="auto" ng-trim="false"></textarea>
                     </div>
 
                     <div class="im_send_buttons_wrap clearfix">


### PR DESCRIPTION
By default, Angular trims whitespaces in the binding. This behaviour can be avoided by setting `ng-trim` to `false`, therefore keeping the whitespaces, as done in the mobile clients.