### PR TITLE
Fixed richtext when height of window changes

### DIFF
--- a/app/less/desktop.less
+++ b/app/less/desktop.less
@@ -1245,7 +1245,6 @@ a.im_panel_peer_photo .peer_initials {
   .composer {
     &_rich_textarea,
     &_textarea {
-      min-height: 25px;
       padding-right: 25px;
     }
 


### PR DESCRIPTION
When download bar or inspector element or anything change the height of page, leaves the richtext crazy.
The ideal in this case is leave a height not defined because will adapt himself.