### PR TITLE
Fixes for Hebrew support

### DIFF
--- a/app/js/lib/utils.js
+++ b/app/js/lib/utils.js
@@ -397,7 +397,7 @@ function encodeEntities(value) {
       var low = value.charCodeAt(1);
       return '&#' + (((hi - 0xD800) * 0x400) + (low - 0xDC00) + 0x10000) + ';';
     }).
-    replace(/([^\#-~| |!])/g, function (value) { // non-alphanumeric
+    replace(/([^\#-~| |!א-ת])/g, function (value) { // non-alphanumeric
       return '&#' + value.charCodeAt(0) + ';';
     }).
     replace(/</g, '&lt;').

--- a/app/less/desktop.less
+++ b/app/less/desktop.less
@@ -1246,7 +1246,7 @@ a.im_panel_peer_photo .peer_initials {
     &_rich_textarea,
     &_textarea {
       min-height: 25px;
-      padding-right: 25px;
+      padding-right: 40px;
     }
 
     &_progress_icon_wrap {


### PR DESCRIPTION
Fixed issue #1076: RTL text overlaps emoticon button.
Fixed issue #1099: Initials for a contact without a photo are displayed incorrectly if the contact's name is in hebrew.
