### PR TITLE
fix scrollbar for RTL languages

### DIFF
--- a/app/js/message_composer.js
+++ b/app/js/message_composer.js
@@ -714,13 +714,6 @@ MessageComposer.prototype.setUpInput = function () {
   } else {
     this.setUpPlaintext();
   }
-
-  if (!Config.Mobile) {
-    var sbWidth = getScrollWidth();
-    if (sbWidth) {
-      (this.richTextareaEl || this.textareaEl).css({marginRight: -sbWidth});
-    }
-  }
 }
 
 MessageComposer.prototype.setInlinePlaceholder = function (prefix, placeholder) {

--- a/app/less/desktop.less
+++ b/app/less/desktop.less
@@ -1140,8 +1140,9 @@ a.im_panel_peer_photo .peer_initials {
   box-shadow: none;
   outline: none;
   box-shadow: 0 1px 0 0 #e8e8e8;
-  padding: 1px 30px 1px 0;
+  padding: 1px 0 1px 0;
   margin: 0;
+  margin-right: 30px;
   min-height: 50px;
   line-height: 20px;
   height: auto;


### PR DESCRIPTION
In the current style configuration (for desktop), RTL languages are overlapping with the emoji icon.

Here's an example:
LTR before:
![ltr_before](https://cloud.githubusercontent.com/assets/10427304/15448840/a6e9ac78-1f75-11e6-819d-f4f1c12b407c.PNG)

RTL before:
![before](https://cloud.githubusercontent.com/assets/10427304/15448843/ace3d428-1f75-11e6-9623-0156242b7d39.PNG)

LTR after:
![ltr_after](https://cloud.githubusercontent.com/assets/10427304/15448844/b505eeac-1f75-11e6-8e5c-9c269235c944.PNG)

RTL after:
![after](https://cloud.githubusercontent.com/assets/10427304/15448845/b91ec266-1f75-11e6-94de-44ab30fbbbf3.PNG)

though it looks liks the scrollbar is useless since the container expands when you write.

should it be removed alltogether? or after a certain amount of lines it becomes active?

thx for the great tool! :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zhukov/webogram/1148)
<!-- Reviewable:end -->
