### PR TITLE
Hide autocompleter suggestions on message submit

### DIFF
--- a/app/js/directives.js
+++ b/app/js/directives.js
@@ -1557,6 +1557,8 @@ angular.module('myApp.directives', ['myApp.filters'])
       $(submitBtn).on('mousedown touchstart', onMessageSubmit)
 
       function onMessageSubmit (e) {
+        var self = this
+
         $timeout(function () {
           updateValue()
           $scope.draftMessage.send()
@@ -1564,6 +1566,8 @@ angular.module('myApp.directives', ['myApp.filters'])
           if (composerEmojiPanel) {
             composerEmojiPanel.update()
           }
+
+          self.hideSuggestions()
         }, shouldFocusOnInteraction ? 0 : 100)
         return cancelEvent(e)
       }


### PR DESCRIPTION
This adds a call to `MessageComposer.hideSuggestions()` in the
`onMessageSubmit` function so that the autocompleter is always closed after a
message is sent.
## To Reproduce

On master, create a message like ":D" and send the message. This will trigger
the autocompleter to show up and suggest emojis, but after the message is sent,
the autocompleter will still be visible.

On this branch, sending the same message will close the autocompleter after the
message is sent.

Fix #1203
