### PR TITLE
Add tooltip to show full file name on hover

### DIFF
--- a/app/partials/desktop/audio_player.html
+++ b/app/partials/desktop/audio_player.html
@@ -8,7 +8,7 @@
 			<span ng-switch-default class="audio_player_duration" ng-bind="mediaPlayer.player.duration || audio.duration | duration"></span>
 		</div>
 		<span class="copyonly">[ </span>
-		<a ng-click="download()" class="audio_player_title" ng-switch="::audio.audioTitle.length > 0 ? 2 : (audio.file_name.length > 0 ? 1 : 0)">
+		<a ng-attr-title="{{audio.file_name}}" ng-click="download()" class="audio_player_title" ng-switch="::audio.audioTitle.length > 0 ? 2 : (audio.file_name.length > 0 ? 1 : 0)">
 			<span ng-switch-when="2">
 				<strong ng-bind="::audio.audioPerformer"></strong>
 				<span ng-bind="::(audio.audioPerformer ? '– ' : '') + audio.audioTitle"></span>

--- a/app/partials/desktop/message_attach_document.html
+++ b/app/partials/desktop/message_attach_document.html
@@ -64,7 +64,7 @@
 
     <div class="im_message_document_info">
       <div class="im_message_document_name_wrap">
-        <span class="copyonly">[</span><a href="" ng-click="docOpen()" class="im_message_document_name" ng-bind="::media.document.file_name"></a><span class="copyonly">]</span>
+        <span class="copyonly">[</span><a href="" ng-attr-title="{{media.document.file_name}}" ng-click="docOpen()" class="im_message_document_name" ng-bind="::media.document.file_name"></a><span class="copyonly">]</span>
         <span class="im_message_document_size" ng-if="!media.document.progress.enabled" ng-bind="::media.document.size | formatSize"></span>
         <span class="im_message_document_size" ng-if="media.document.progress.enabled" ng-bind="media.document.progress | formatSizeProgress"></span>
       </div>

--- a/app/partials/desktop/message_attach_pending.html
+++ b/app/partials/desktop/message_attach_pending.html
@@ -4,7 +4,7 @@
   </div>
   <div class="im_message_document_info">
     <div class="im_message_document_name_wrap">
-      <span class="im_message_document_name" ng-bind="::media.file_name"></span>
+      <span ng-attr-title="{{media.file_name}}" class="im_message_document_name" ng-bind="::media.file_name"></span>
       <span class="im_message_document_size" ng-if="media.progress" ng-bind="media.progress | formatSizeProgress"></span>
     </div>
     <div class="clearfix im_message_cancelable_progress_wrap">


### PR DESCRIPTION
Works for audios, documents and pending (uploads).

Not sure if it should be added to mobile partials too. 
Also, not sure if it's needed for other types of attachments.

Please tell me if there's something to fix.

Also not sure if #1034 is needed after this.