### PR TITLE
Add "badges" for admins in member list

### DIFF
--- a/app/less/app.less
+++ b/app/less/app.less
@@ -4734,4 +4734,16 @@ a.countries_modal_search_clear {
   }
 }
 
+.md_modal_admin_badge {
+  display: block;
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 6px;
+  background: #bfbfbf;
+  color: #fff;
+  &_creator {
+    background: #64c270;
+  }
+}
 

--- a/app/partials/desktop/channel_modal.html
+++ b/app/partials/desktop/channel_modal.html
@@ -126,6 +126,12 @@
             <a ng-if="participant.canLeave" ng-click="leaveChannel()" class="md_modal_list_peer_action pull-right" my-i18n="group_modal_menu_leave"></a>
             <a ng-if="participant.canKick" ng-click="kickFromChannel(participant.user_id)" class="md_modal_list_peer_action pull-right" my-i18n="group_modal_members_kick"></a>
 
+            <span ng-switch="participant._" class="pull-left">
+                  <span ng-switch-when="channelParticipantEditor" class="md_modal_admin_badge"></span>
+                  <span ng-switch-when="channelParticipantModerator" class="md_modal_admin_badge"></span>
+                  <span ng-switch-when="channelParticipantCreator" class="md_modal_admin_badge md_modal_admin_badge_creator"></span>
+            </span>
+
             <a class="md_modal_list_peer_photo pull-left" my-peer-photolink="::participant.user_id" img-class="md_modal_list_peer_photo"></a>
 
             <div class="md_modal_list_peer_name">

--- a/app/partials/desktop/chat_modal.html
+++ b/app/partials/desktop/chat_modal.html
@@ -112,6 +112,11 @@
             <a ng-if="participant.canLeave" ng-click="leaveGroup()" class="md_modal_list_peer_action pull-right" my-i18n="group_modal_menu_delete_group"></a>
             <a ng-if="participant.canKick" ng-click="kickFromGroup(participant.user_id)" class="md_modal_list_peer_action pull-right" my-i18n="group_modal_members_kick"></a>
 
+            <span ng-switch="participant._" class="pull-left">
+                  <span ng-switch-when="chatParticipantAdmin" class="md_modal_admin_badge"></span>
+                  <span ng-switch-when="chatParticipantCreator" class="md_modal_admin_badge md_modal_admin_badge_creator"></span>
+            </span>
+
             <a class="md_modal_list_peer_photo pull-left" my-peer-photolink="::participant.user_id" img-class="md_modal_list_peer_photo"></a>
 
             <div class="md_modal_list_peer_name">

--- a/app/partials/mobile/channel_modal.html
+++ b/app/partials/mobile/channel_modal.html
@@ -112,6 +112,12 @@
             <a ng-if="participant.canKick" ng-click="kickFromChannel(participant.user_id)" class="chat_modal_participant_kick pull-right" my-i18n="group_modal_members_kick"></a>
             <a ng-if="participant.canLeave" ng-click="leaveChannel()" class="chat_modal_participant_kick pull-right" my-i18n="group_modal_menu_leave"></a>
 
+            <span ng-switch="participant._" class="pull-left">
+                  <span ng-switch-when="channelParticipantEditor" class="md_modal_admin_badge"></span>
+                  <span ng-switch-when="channelParticipantModerator" class="md_modal_admin_badge"></span>
+                  <span ng-switch-when="channelParticipantCreator" class="md_modal_admin_badge md_modal_admin_badge_creator"></span>
+            </span>
+
             <a class="chat_modal_participant_photo pull-left" my-peer-photolink="participant.user_id" img-class="chat_modal_participant_photo" status="true"></a>
 
             <div class="chat_modal_participant_name">

--- a/app/partials/mobile/chat_modal.html
+++ b/app/partials/mobile/chat_modal.html
@@ -98,6 +98,11 @@
             <a ng-if="participant.canKick" ng-click="kickFromGroup(participant.user_id)" class="chat_modal_participant_kick pull-right" my-i18n="group_modal_members_kick"></a>
             <a ng-if="participant.canLeave" ng-click="leaveGroup()" class="chat_modal_participant_kick pull-right" my-i18n="group_modal_menu_delete_group"></a>
 
+            <span ng-switch="participant._" class="pull-left">
+                  <span ng-switch-when="chatParticipantAdmin" class="md_modal_admin_badge"></span>
+                  <span ng-switch-when="chatParticipantCreator" class="md_modal_admin_badge md_modal_admin_badge_creator"></span>
+            </span>
+
             <a class="chat_modal_participant_photo pull-left" my-peer-photolink="participant.user_id" img-class="chat_modal_participant_photo" status="true"></a>
 
             <div class="chat_modal_participant_name">


### PR DESCRIPTION
Like stars in other apps.
Works in both channels (supergroups) and normal groups.

Here are Creator, Member and Admin.

Desktop:
![image](https://cloud.githubusercontent.com/assets/11808223/20583810/4354230c-b1fe-11e6-9e0f-f4ee7a52dbf7.png)
Mobile:
![image](https://cloud.githubusercontent.com/assets/11808223/20583975/7e275a7a-b1ff-11e6-93da-7d4fd3e48985.png)

Not sure if it should be redesigned. I'm personally thinking about placing a badge before photo so it's easier to notice it when scrolling fast.
Also we may add a circle border around the profile pics of admins.

We can't place anything on right side like other apps because Webogram has buttons there.