### PR TITLE
allow editting mentions text for users with usernames

### DIFF
--- a/app/js/message_composer.js
+++ b/app/js/message_composer.js
@@ -785,7 +785,12 @@ MessageComposer.prototype.setUpAutoComplete = function () {
       }
       EmojiHelper.pushPopularEmoji(code)
     }
-    if (mention = target.attr('data-mention')) {
+    if (e.altKey || !target.attr('data-username')) {
+      mention = target.attr('data-user-id')
+    } else {
+      mention = target.attr('data-username')
+    }
+    if (mention) {
       self.onMentionSelected(mention, target.attr('data-name'))
     }
     if (command = target.attr('data-command')) {
@@ -911,7 +916,12 @@ MessageComposer.prototype.onKeyEvent = function (e) {
           EmojiHelper.pushPopularEmoji(code)
           return cancelEvent(e)
         }
-        if (mention = currentSel.attr('data-mention')) {
+        if (e.altKey || !currentSel.attr('data-username')) {
+          mention = currentSel.attr('data-user-id')
+        } else {
+          mention = currentSel.attr('data-username')
+        }
+        if (mention) {
           this.onMentionSelected(mention, currentSel.attr('data-name'))
           return cancelEvent(e)
         }

--- a/app/partials/desktop/composer_dropdown.html
+++ b/app/partials/desktop/composer_dropdown.html
@@ -2,7 +2,7 @@
 
   <ul ng-switch-when="mentions" class="composer_dropdown">
     <li ng-repeat="user in mentionUsers">
-      <a class="composer_mention_option" data-mention="{{user.username.length > 0 ? user.username : ('#' + user.id)}}" data-name="{{user.first_name}}">
+      <a class="composer_mention_option" data-user-id="{{'#' + user.id}}" data-username="{{user.username}}" data-name="{{user.first_name}}">
         <span class="composer_user_photo" my-peer-photolink="user.id" img-class="composer_user_photo"></span>
         <span class="composer_user_name" ng-bind-html="user.rFullName"></span>
         <span class="composer_user_mention" ng-if="user.username.length > 0" ng-bind="'@' + user.username"></span>


### PR DESCRIPTION
When entering `@$name` an autocomplete shows up showing possible users to mention here. Selecting a user who has set a username for his account will insert `@username` into the composer box. But for users without a dedicated username it will insert
> @1234567 (firstname)

where `1234567` is the internal id of the telegram account and `firstname` is the users first name from the _local_ address book (i.e. how _I_ saved the user in _my_ address book).

In the latter case it is possible to manually change the later to be displayed text for the mention. Although this actually being just a side effect of the implementation I consider this to be **a real feature** and I'd really like to be able to do the same with users which **do** have a username set - especially if it's an uncommon/unknown nickname in the context of the current group...

Therefore, this patch: when holding the Alt* key while selecting the user from the autocomplete suggestions it forces the latter format regardless of the set username, allowing to again manually edit the displayed text.

\* the hotkey may still easily be changed to Ctrl or Shift, but I felt Alt to be the most fitting here :relaxed:
(although it may collide with the window manager's shortcut for switching windows on many systems - but still works with Alt+Enter and Alt+Click)