### PR TITLE
Added test for ChangeLogModalController, AppFooterController and PeerSelectController

### DIFF
--- a/test/unit/AppFooterController.js
+++ b/test/unit/AppFooterController.js
@@ -1,0 +1,39 @@
+describe('AppFooterController', function() {
+  var $controller, $rootScope, $scope, $location, service, serviceFlag;
+
+  beforeEach(module('myApp.controllers'));
+
+  beforeEach(function () {
+    serviceFlag = false;
+    service = {
+      switchLayout: function(parameter){
+        serviceFlag = true;
+      }
+    }
+
+    inject(function (_$controller_, _$rootScope_, _$location_) {
+        $controller = _$controller_;
+        $rootScope = _$rootScope_;
+        $location = _$location_;
+
+        $scope = $rootScope.$new();
+        $controller('AppFooterController', {
+            $scope: $scope,
+            LayoutSwitchService: service
+        });
+    });
+  });
+
+  // define tests
+  it('compiles', function (done) {
+    expect(true).toBe(true);
+    done();
+  });
+
+  it('calls the right function', function (done) {
+    expect(serviceFlag).toBe(false);
+    $scope.switchLayout(null);
+    expect(serviceFlag).toBe(true);
+    done();
+  });
+})

--- a/test/unit/AppFooterController.js
+++ b/test/unit/AppFooterController.js
@@ -1,5 +1,5 @@
 describe('AppFooterController', function() {
-  var $controller, $rootScope, $scope, $location, service, serviceFlag;
+  var $controller, $scope, service, serviceFlag;
 
   beforeEach(module('myApp.controllers'));
 
@@ -11,12 +11,10 @@ describe('AppFooterController', function() {
       }
     }
 
-    inject(function (_$controller_, _$rootScope_, _$location_) {
+    inject(function (_$controller_, _$rootScope_) {
         $controller = _$controller_;
-        $rootScope = _$rootScope_;
-        $location = _$location_;
 
-        $scope = $rootScope.$new();
+        $scope = _$rootScope_.$new();
         $controller('AppFooterController', {
             $scope: $scope,
             LayoutSwitchService: service

--- a/test/unit/AppFooterControllerSpec.js
+++ b/test/unit/AppFooterControllerSpec.js
@@ -1,32 +1,34 @@
-describe('AppFooterController', function () {
-  var $controller, $scope, service, serviceFlag;
+/* global describe, it, inject, expect, beforeEach */
 
-  beforeEach(module('myApp.controllers'));
+describe('AppFooterController', function () {
+  var $controller, $scope, service, serviceFlag
+
+  beforeEach(module('myApp.controllers'))
 
   beforeEach(function () {
-    serviceFlag = false;
+    serviceFlag = false
     service = {
       switchLayout: function (parameter) {
-        serviceFlag = true;
+        serviceFlag = true
       }
     }
 
     inject(function (_$controller_, _$rootScope_) {
-        $controller = _$controller_;
+      $controller = _$controller_
 
-        $scope = _$rootScope_.$new();
-        $controller('AppFooterController', {
-            $scope: $scope,
-            LayoutSwitchService: service
-        });
-    });
-  });
+      $scope = _$rootScope_.$new()
+      $controller('AppFooterController', {
+        $scope: $scope,
+        LayoutSwitchService: service
+      })
+    })
+  })
 
   // define tests
   it('calls the right function', function (done) {
-    expect(serviceFlag).toBe(false);
-    $scope.switchLayout(null);
-    expect(serviceFlag).toBe(true);
-    done();
-  });
+    expect(serviceFlag).toBe(false)
+    $scope.switchLayout(null)
+    expect(serviceFlag).toBe(true)
+    done()
+  })
 })

--- a/test/unit/AppFooterControllerSpec.js
+++ b/test/unit/AppFooterControllerSpec.js
@@ -1,4 +1,4 @@
-describe('AppFooterController', function() {
+describe('AppFooterController', function () {
   var $controller, $scope, service, serviceFlag;
 
   beforeEach(module('myApp.controllers'));
@@ -6,7 +6,7 @@ describe('AppFooterController', function() {
   beforeEach(function () {
     serviceFlag = false;
     service = {
-      switchLayout: function(parameter){
+      switchLayout: function (parameter) {
         serviceFlag = true;
       }
     }
@@ -23,11 +23,6 @@ describe('AppFooterController', function() {
   });
 
   // define tests
-  it('compiles', function (done) {
-    expect(true).toBe(true);
-    done();
-  });
-
   it('calls the right function', function (done) {
     expect(serviceFlag).toBe(false);
     $scope.switchLayout(null);

--- a/test/unit/ChangelogModalControlelerSpec.js
+++ b/test/unit/ChangelogModalControlelerSpec.js
@@ -1,0 +1,71 @@
+describe('ChangeLogModalController', function() {
+  // Define used variables
+  var $controller, $rootScope, $scope, $location, modal, modalFlag;
+
+  // Create scope, inject data and modals
+  beforeEach(module('myApp.controllers'));
+  beforeEach(function () {
+    modalFlag = false;
+    modal = {
+      open: function (data) {
+        modalFlag = true;
+      }
+    };
+
+    inject(function (_$controller_, _$rootScope_, _$location_) {
+        $controller = _$controller_;
+        $rootScope = _$rootScope_;
+        $location = _$location_;
+
+        $scope = $rootScope.$new();
+        $controller('ChangelogModalController', {
+            $scope: $scope,
+            $modal: modal
+        });
+    });
+  });
+
+  // define tests
+  it('will have standard data when no function is called', function (done) {
+    expect($scope.changelogHidden).toBe(false);
+    expect($scope.changelogShown).toBe(false);
+    expect($scope.currentVersion).toBe('0.5.5');
+    expect($scope.lastVersion).toBe('0.5.4');
+    done();
+  });
+
+  it('will show the changelog', function (done) {
+    $scope.showAllVersions();
+    expect($scope.changelogHidden).toBe(false);
+    expect($scope.changelogShown).toBe(true);
+    done();
+  });
+
+  it('will allow to show any version when "changelogShown" is true', function (done) {
+    $scope.changelogShown = true;
+    expect($scope.canShowVersion(null)).toBe(true);
+    expect($scope.canShowVersion('0.0.1')).toBe(true);
+    expect($scope.canShowVersion('0.1.0')).toBe(true);
+    expect($scope.canShowVersion('1.0.0')).toBe(true);
+    done();
+  });
+
+  it('will allow the version to be shown when the current verion is bigger than the last function', function (done) {
+    expect($scope.canShowVersion('100.100.100')).toBe(true);
+    done();
+  });
+
+  it('won\'t allow the version to be shown when it is smaller than the current version', function (done) {
+    expect($scope.changelogHidden).toBe(false);
+    expect($scope.canShowVersion('0.0.0')).toBe(false);
+    expect($scope.changelogHidden).toBe(true);
+    done();
+  });
+
+  it('will call modal when the changeUsername function is called', function (done) {
+    expect(modalFlag).toBe(false);
+    $scope.changeUsername();
+    expect(modalFlag).toBe(true);
+    done();
+  });
+})

--- a/test/unit/ChangelogModalControlelerSpec.js
+++ b/test/unit/ChangelogModalControlelerSpec.js
@@ -1,9 +1,8 @@
 describe('ChangeLogModalController', function() {
-  // Define used variables
   var $controller, $rootScope, $scope, $location, modal, modalFlag;
 
-  // Create scope, inject data and modals
   beforeEach(module('myApp.controllers'));
+
   beforeEach(function () {
     modalFlag = false;
     modal = {
@@ -29,7 +28,7 @@ describe('ChangeLogModalController', function() {
   it('will have standard data when no function is called', function (done) {
     expect($scope.changelogHidden).toBe(false);
     expect($scope.changelogShown).toBe(false);
-    expect($scope.currentVersion).toBe('0.5.5');
+    expect($scope.currentVersion).toBe(Config.App.version);
     expect($scope.lastVersion).toBe('0.5.4');
     done();
   });

--- a/test/unit/ChangelogModalControlelerSpec.js
+++ b/test/unit/ChangelogModalControlelerSpec.js
@@ -1,5 +1,5 @@
 describe('ChangeLogModalController', function() {
-  var $controller, $rootScope, $scope, $location, modal, modalFlag;
+  var $controller, $rootScope, $scope, modal, modalFlag;
 
   beforeEach(module('myApp.controllers'));
 
@@ -11,12 +11,10 @@ describe('ChangeLogModalController', function() {
       }
     };
 
-    inject(function (_$controller_, _$rootScope_, _$location_) {
+    inject(function (_$controller_, _$rootScope_) {
         $controller = _$controller_;
-        $rootScope = _$rootScope_;
-        $location = _$location_;
 
-        $scope = $rootScope.$new();
+        $scope = _$rootScope_.$new();
         $controller('ChangelogModalController', {
             $scope: $scope,
             $modal: modal
@@ -29,7 +27,6 @@ describe('ChangeLogModalController', function() {
     expect($scope.changelogHidden).toBe(false);
     expect($scope.changelogShown).toBe(false);
     expect($scope.currentVersion).toBe(Config.App.version);
-    expect($scope.lastVersion).toBe('0.5.4');
     done();
   });
 

--- a/test/unit/ChangelogModalControlelerSpec.js
+++ b/test/unit/ChangelogModalControlelerSpec.js
@@ -1,4 +1,4 @@
-describe('ChangeLogModalController', function() {
+describe('ChangeLogModalController', function () {
   var $controller, $rootScope, $scope, modal, modalFlag;
 
   beforeEach(module('myApp.controllers'));

--- a/test/unit/ChangelogModalControlelerSpec.js
+++ b/test/unit/ChangelogModalControlelerSpec.js
@@ -1,67 +1,69 @@
-describe('ChangeLogModalController', function () {
-  var $controller, $rootScope, $scope, modal, modalFlag;
+/* global describe, it, inject, expect, beforeEach, Config */
 
-  beforeEach(module('myApp.controllers'));
+describe('ChangeLogModalController', function () {
+  var $controller, $scope, modal, modalFlag
+
+  beforeEach(module('myApp.controllers'))
 
   beforeEach(function () {
-    modalFlag = false;
+    modalFlag = false
     modal = {
       open: function (data) {
-        modalFlag = true;
+        modalFlag = true
       }
-    };
+    }
 
     inject(function (_$controller_, _$rootScope_) {
-        $controller = _$controller_;
+      $controller = _$controller_
 
-        $scope = _$rootScope_.$new();
-        $controller('ChangelogModalController', {
-            $scope: $scope,
-            $modal: modal
-        });
-    });
-  });
+      $scope = _$rootScope_.$new()
+      $controller('ChangelogModalController', {
+        $scope: $scope,
+        $modal: modal
+      })
+    })
+  })
 
   // define tests
   it('will have standard data when no function is called', function (done) {
-    expect($scope.changelogHidden).toBe(false);
-    expect($scope.changelogShown).toBe(false);
-    expect($scope.currentVersion).toBe(Config.App.version);
-    done();
-  });
+    expect($scope.changelogHidden).toBe(false)
+    expect($scope.changelogShown).toBe(false)
+    expect($scope.currentVersion).toBe(Config.App.version)
+    done()
+  })
 
   it('will show the changelog', function (done) {
-    $scope.showAllVersions();
-    expect($scope.changelogHidden).toBe(false);
-    expect($scope.changelogShown).toBe(true);
-    done();
-  });
+    $scope.showAllVersions()
+    expect($scope.changelogHidden).toBe(false)
+    expect($scope.changelogShown).toBe(true)
+    done()
+  })
 
   it('will allow to show any version when "changelogShown" is true', function (done) {
-    $scope.changelogShown = true;
-    expect($scope.canShowVersion(null)).toBe(true);
-    expect($scope.canShowVersion('0.0.1')).toBe(true);
-    expect($scope.canShowVersion('0.1.0')).toBe(true);
-    expect($scope.canShowVersion('1.0.0')).toBe(true);
-    done();
-  });
+    $scope.changelogShown = true
+    expect($scope.canShowVersion(null)).toBe(true)
+    expect($scope.canShowVersion('0.0.1')).toBe(true)
+    expect($scope.canShowVersion('0.1.0')).toBe(true)
+    expect($scope.canShowVersion('1.0.0')).toBe(true)
+    done()
+  })
 
   it('will allow the version to be shown when the current verion is bigger than the last function', function (done) {
-    expect($scope.canShowVersion('100.100.100')).toBe(true);
-    done();
-  });
+    expect($scope.canShowVersion('100.100.100')).toBe(true)
+    done()
+  })
 
   it('won\'t allow the version to be shown when it is smaller than the current version', function (done) {
-    expect($scope.changelogHidden).toBe(false);
-    expect($scope.canShowVersion('0.0.0')).toBe(false);
-    expect($scope.changelogHidden).toBe(true);
-    done();
-  });
+    expect($scope.changelogHidden).toBe(false)
+    expect($scope.canShowVersion('0.0.0')).toBe(false)
+    expect($scope.changelogHidden).toBe(true)
+    done()
+  })
 
   it('will call modal when the changeUsername function is called', function (done) {
-    expect(modalFlag).toBe(false);
-    $scope.changeUsername();
-    expect(modalFlag).toBe(true);
-    done();
-  });
+    expect(modalFlag).toBe(false)
+    $scope.changeUsername()
+    expect(modalFlag).toBe(true)
+    done()
+  })
 })

--- a/test/unit/PeerSelectControllerSpec.js
+++ b/test/unit/PeerSelectControllerSpec.js
@@ -1,30 +1,32 @@
-describe('PeerSelectController', function () {
-  var $controller, $scope, $q, $mod, $APManager, $EService, createController, timeoutTime, $promiseData, $promise, $promiseFlag;
+/* global describe, it, inject, expect, beforeEach */
 
-  beforeEach(module('myApp.controllers'));
+describe('PeerSelectController', function () {
+  var $controller, $scope, $q, $mod, $APManager, $EService, createController, timeoutTime, $promiseData, $promise, $promiseFlag
+
+  beforeEach(module('myApp.controllers'))
 
   beforeEach(function () {
     // The modalInstance will propably usually give a boolean as return.
     // However, for testing purposes it is important to gain knowledge about the input of the function
     $mod = {
       close: function (arr) {
-        return arr;
+        return arr
       }
-    };
+    }
 
-    timeoutTime = 1000;
+    timeoutTime = 1000
 
     $APManager = {
-      getPeerString: function (str){
-        return "P".concat(str);
+      getPeerString: function (str) {
+        return 'P'.concat(str)
       },
       getPeerID: function (str) {
-        return str.slice(-1);
+        return str.slice(-1)
       },
       getPeer: function (id) {
-        return id.concat("peer");
+        return id.concat('peer')
       }
-    };
+    }
 
     // The controller is created in the test in order to test different initial content of scope variables.
     createController = function () {
@@ -34,224 +36,221 @@ describe('PeerSelectController', function () {
         $q: $q,
         AppPeersManager: $APManager,
         ErrorService: $EService
-      });
-    };
+      })
+    }
 
-    $promiseFlag = false;
+    $promiseFlag = false
     $promise = {
       then: function (f) {
-        $promiseFlag = true;
-        f();
+        $promiseFlag = true
+        f()
       }
-    };
+    }
 
     $EService = {
       confirm: function (data) {
-        $promiseData = data;
-        return $promise;
+        $promiseData = data
+        return $promise
       }
-    };
+    }
 
     $q = {
       when: function () {
-        return $promise;
+        return $promise
       }
-    };
+    }
 
     inject(function (_$controller_, _$rootScope_) {
-      $controller = _$controller_;
-      $scope = _$rootScope_.$new();
-    });
-  });
+      $controller = _$controller_
+      $scope = _$rootScope_.$new()
+    })
+  })
 
   it('initialises properties', function (done) {
-    createController();
+    createController()
 
     // Set timer to give the controller time to resolve.
     setTimeout(function () {
-      expect($scope.selectedPeers).toBeDefined();
-      expect($scope.selectedPeersIDs).toBeDefined();
-      expect($scope.selectedCount).toBeDefined();
-    }, timeoutTime);
+      expect($scope.selectedPeers).toBeDefined()
+      expect($scope.selectedPeersIDs).toBeDefined()
+      expect($scope.selectedCount).toBeDefined()
+    }, timeoutTime)
 
-    done();
-  });
+    done()
+  })
 
   it('compiles with a shareLinkPromise that resolves', function (done) {
-    var expected = "testURL";
+    var expected = 'testURL'
     $scope.shareLinkPromise = {
       then: function (resolve, reject) {
-        setTimeout(resolve(expected), timeoutTime);
+        setTimeout(resolve(expected), timeoutTime)
       }
     }
-    createController();
+    createController()
 
     setTimeout(function () {
-      expect($scope.shareLink.loading).toBe(true);
-      expect($scope.shareLink.url).not.toBeDefined();
+      expect($scope.shareLink.loading).toBe(true)
+      expect($scope.shareLink.url).not.toBeDefined()
       setTimeout(function () {
-        expect($scope.shareLink.url).toBe(expected);
-      }, timeoutTime);
-    }, timeoutTime);
-    done();
-  });
-
+        expect($scope.shareLink.url).toBe(expected)
+      }, timeoutTime)
+    }, timeoutTime)
+    done()
+  })
 
   it('compiles with a shareLinkPromise that doesn\'t resolve', function (done) {
     $scope.shareLinkPromise = {
       then: function (resolve, reject) {
-        setTimeout(reject(), timeoutTime);
+        setTimeout(reject(), timeoutTime)
       }
     }
-    createController();
+    createController()
 
     setTimeout(function () {
-      expect($scope.shareLink.loading).toBe(true);
+      expect($scope.shareLink.loading).toBe(true)
       setTimeout(function () {
-        expect($scope.shareLink).not.toBeDefined();
-      }, timeoutTime);
-    }, timeoutTime);
-    done();
-  });
+        expect($scope.shareLink).not.toBeDefined()
+      }, timeoutTime)
+    }, timeoutTime)
+    done()
+  })
 
   it('can select and submit a single dialog without confirmed type', function (done) {
-    createController();
+    createController()
 
-    $scope.dialogSelect("dialogX");
+    $scope.dialogSelect('dialogX')
 
-    expect($promiseData).not.toBeDefined();
-    expect($promiseFlag).toBe(true);
+    expect($promiseData).not.toBeDefined()
+    expect($promiseFlag).toBe(true)
 
-    done();
-  });
+    done()
+  })
 
   it('can select and submit a single dialog with confirmed type', function (done) {
-    createController();
+    createController()
 
-    $scope.confirm_type = "INVITE_TO_GROUP";
-    $scope.dialogSelect("dialogX");
+    $scope.confirm_type = 'INVITE_TO_GROUP'
+    $scope.dialogSelect('dialogX')
 
     var expected = {
-      type: "INVITE_TO_GROUP",
-      peer_id: "X",
-      peer_data: "Xpeer"
-    };
+      type: 'INVITE_TO_GROUP',
+      peer_id: 'X',
+      peer_data: 'Xpeer'
+    }
 
-    expect($promiseData).toEqual(expected);
-    expect($promiseFlag).toBe(true);
+    expect($promiseData).toEqual(expected)
+    expect($promiseFlag).toBe(true)
 
-    done();
-  });
+    done()
+  })
 
   it('can select a dialog', function (done) {
-    createController();
+    createController()
 
-    $scope.multiSelect = true;
-    $scope.dialogSelect("dialogX");
+    $scope.multiSelect = true
+    $scope.dialogSelect('dialogX')
 
-    var expected = ["X"];
+    var expected = ['X']
 
-    expect($scope.selectedPeers["X"]).toBe("Xpeer");
-    expect($scope.selectedCount).toBe(1);
-    expect($scope.selectedPeerIDs).toEqual(expected);
+    expect($scope.selectedPeers['X']).toBe('Xpeer')
+    expect($scope.selectedCount).toBe(1)
+    expect($scope.selectedPeerIDs).toEqual(expected)
 
-    done();
-  });
+    done()
+  })
 
   it('can select multiple dialogs', function (done) {
-    createController();
+    createController()
 
-    $scope.multiSelect = true;
-    $scope.dialogSelect("dialogX");
-    $scope.dialogSelect("dialogZ");
-    $scope.dialogSelect("dialogY");
+    $scope.multiSelect = true
+    $scope.dialogSelect('dialogX')
+    $scope.dialogSelect('dialogZ')
+    $scope.dialogSelect('dialogY')
 
-    var expected = ["Y", "Z", "X"];
+    var expected = ['Y', 'Z', 'X']
 
-    expect($scope.selectedCount).toBe(3);
-    expect($scope.selectedPeerIDs).toEqual(expected);
+    expect($scope.selectedCount).toBe(3)
+    expect($scope.selectedPeerIDs).toEqual(expected)
 
-    done();
-  });
+    done()
+  })
 
   it('can unselect a dialog', function (done) {
-    createController();
+    createController()
 
-    $scope.multiSelect = true;
-    $scope.selectedCount = 1;
-    $scope.selectedPeers["Y"] = "aYPeer";
-    $scope.selectedPeerIDs.unshift("Y");
+    $scope.multiSelect = true
+    $scope.selectedCount = 1
+    $scope.selectedPeers['Y'] = 'aYPeer'
+    $scope.selectedPeerIDs.unshift('Y')
 
-    $scope.dialogSelect("dialogY");
+    $scope.dialogSelect('dialogY')
 
-    var expected = [];
+    var expected = []
 
-    expect($scope.selectedPeers["Y"]).not.toBeDefined()
-    expect($scope.selectedCount).toBe(0);
-    expect($scope.selectedPeerIDs).toEqual(expected);
+    expect($scope.selectedPeers['Y']).not.toBeDefined()
+    expect($scope.selectedCount).toBe(0)
+    expect($scope.selectedPeerIDs).toEqual(expected)
 
-    done();
-  });
+    done()
+  })
 
   it('can select multiple dialogs', function (done) {
-    createController();
+    createController()
 
-    $scope.multiSelect = true;
-    $scope.dialogSelect("dialogX");
-    $scope.dialogSelect("dialogZ");
-    $scope.dialogSelect("dialogY");
-    $scope.dialogSelect("dialogZ");
+    $scope.multiSelect = true
+    $scope.dialogSelect('dialogX')
+    $scope.dialogSelect('dialogZ')
+    $scope.dialogSelect('dialogY')
+    $scope.dialogSelect('dialogZ')
 
-    var expected = ["Y", "X"];
+    var expected = ['Y', 'X']
 
-    expect($scope.selectedCount).toBe(2);
-    expect($scope.selectedPeerIDs).toEqual(expected);
+    expect($scope.selectedCount).toBe(2)
+    expect($scope.selectedPeerIDs).toEqual(expected)
 
-    done();
-  });
+    done()
+  })
 
   it('can\'t submit a empty set of dialogs', function (done) {
-    createController();
+    createController()
 
-    expect($scope.submitSelected()).not.toBeDefined();
+    expect($scope.submitSelected()).not.toBeDefined()
 
-    done();
-  });
-
+    done()
+  })
 
   it('can submit one dialog', function (done) {
-    createController();
+    createController()
 
-    $scope.selectedCount = 1;
-    $scope.selectedPeers["test"] = "peer";
-    var expected = ["Ptest"];
-    expect($scope.submitSelected()).toEqual(expected);
+    $scope.selectedCount = 1
+    $scope.selectedPeers['test'] = 'peer'
+    var expected = ['Ptest']
+    expect($scope.submitSelected()).toEqual(expected)
 
-    done();
-  });
-
+    done()
+  })
 
   it('can submit multiple dialogs', function (done) {
-    createController();
+    createController()
 
-    $scope.selectedCount = 3;
-    $scope.selectedPeers["test1"] = $scope.selectedPeers["test2"] = $scope.selectedPeers["test4"] = "peer";
+    $scope.selectedCount = 3
+    $scope.selectedPeers['test1'] = $scope.selectedPeers['test2'] = $scope.selectedPeers['test4'] = 'peer'
 
-    var expected = ["Ptest4", "Ptest2" ,"Ptest1"];
-    expect($scope.submitSelected()).toEqual(expected);
+    var expected = ['Ptest4', 'Ptest2', 'Ptest1']
+    expect($scope.submitSelected()).toEqual(expected)
 
-    done();
-  });
+    done()
+  })
 
   it('can toggle', function (done) {
-    createController();
+    createController()
 
-    var broadcastFlag = '';
-    $scope.$broadcast = function (input) { broadcastFlag = input; };
+    var broadcastFlag = ''
+    $scope.$broadcast = function (input) { broadcastFlag = input }
 
-    $scope.toggleSearch();
-    expect(broadcastFlag).toBe('dialogs_search_toggle');
+    $scope.toggleSearch()
+    expect(broadcastFlag).toBe('dialogs_search_toggle')
 
-    done();
-  });
-});
+    done()
+  })
+})

--- a/test/unit/PeerSelectControllerSpec.js
+++ b/test/unit/PeerSelectControllerSpec.js
@@ -1,7 +1,5 @@
 describe('PeerSelectController', function () {
-  var $controller, $scope, $q, $mod, $APManager, $EService;
-  var createController, timeoutTime;
-  var $promiseData, $promise, $promiseFlag;
+  var $controller, $scope, $q, $mod, $APManager, $EService, createController, timeoutTime, $promiseData, $promise, $promiseFlag;
 
   beforeEach(module('myApp.controllers'));
 
@@ -20,7 +18,7 @@ describe('PeerSelectController', function () {
       getPeerString: function (str){
         return "P".concat(str);
       },
-      getPeerID: function(str) {
+      getPeerID: function (str) {
         return str.slice(-1);
       },
       getPeer: function (id) {
@@ -29,7 +27,7 @@ describe('PeerSelectController', function () {
     };
 
     // The controller is created in the test in order to test different initial content of scope variables.
-    createController = function() {
+    createController = function () {
       $controller('PeerSelectController', {
         $scope: $scope,
         $modalInstance: $mod,
@@ -48,7 +46,7 @@ describe('PeerSelectController', function () {
     };
 
     $EService = {
-      confirm: function(data){
+      confirm: function (data) {
         $promiseData = data;
         return $promise;
       }
@@ -66,11 +64,11 @@ describe('PeerSelectController', function () {
     });
   });
 
-  it('compiles', function (done) {
+  it('initialises properties', function (done) {
     createController();
 
     // Set timer to give the controller time to resolve.
-    setTimeout(function(){
+    setTimeout(function () {
       expect($scope.selectedPeers).toBeDefined();
       expect($scope.selectedPeersIDs).toBeDefined();
       expect($scope.selectedCount).toBeDefined();
@@ -80,18 +78,19 @@ describe('PeerSelectController', function () {
   });
 
   it('compiles with a shareLinkPromise that resolves', function (done) {
+    var expected = "testURL";
     $scope.shareLinkPromise = {
       then: function (resolve, reject) {
-        setTimeout(resolve("test"), timeoutTime);
+        setTimeout(resolve(expected), timeoutTime);
       }
     }
     createController();
 
-    setTimeout(function(){
+    setTimeout(function () {
       expect($scope.shareLink.loading).toBe(true);
       expect($scope.shareLink.url).not.toBeDefined();
       setTimeout(function () {
-        expect($scope.shareLink.url).toBe("test");
+        expect($scope.shareLink.url).toBe(expected);
       }, timeoutTime);
     }, timeoutTime);
     done();
@@ -106,7 +105,7 @@ describe('PeerSelectController', function () {
     }
     createController();
 
-    setTimeout(function(){
+    setTimeout(function () {
       expect($scope.shareLink.loading).toBe(true);
       setTimeout(function () {
         expect($scope.shareLink).not.toBeDefined();

--- a/test/unit/PeerSelectControllerSpec.js
+++ b/test/unit/PeerSelectControllerSpec.js
@@ -1,0 +1,256 @@
+describe('PeerSelectController', function () {
+  var $controller, $scope, $q, $mod, $APManager, $EService;
+  var createController;
+  var $promiseData, $promise, $promiseFlag;
+
+  beforeEach(module('myApp.controllers'));
+
+  beforeEach(function () {
+    // The modalInstance will propably usually give a boolean as return.
+    // However, for testing purposes it is important to gain knowledge about the input of the function
+    $mod = {
+      close: function (arr) {
+        return arr;
+      }
+    };
+
+    $APManager = {
+      getPeerString: function (str){
+        return "P".concat(str);
+      },
+      getPeerID: function(str) {
+        return str.slice(-1);
+      },
+      getPeer: function (id) {
+        return id.concat("peer");
+      }
+    };
+
+    // The controller is created in the test in order to test different initial content of scope variables.
+    createController = function() {
+      $controller('PeerSelectController', {
+        $scope: $scope,
+        $modalInstance: $mod,
+        $q: $q,
+        AppPeersManager: $APManager,
+        ErrorService: $EService
+      });
+    };
+
+    $promiseFlag = false;
+    $promise = {
+      then: function (f) {
+        $promiseFlag = true;
+        f();
+      }
+    };
+
+    $EService = {
+      confirm: function(data){
+        $promiseData = data;
+        return $promise;
+      }
+    };
+
+    $q = {
+      when: function () {
+        return $promise;
+      }
+    };
+
+    inject(function (_$controller_, _$rootScope_) {
+      $controller = _$controller_;
+      $scope = _$rootScope_.$new();
+    });
+  });
+
+  it('compiles', function (done) {
+    createController();
+
+    // Set timer to give the controller time to resolve.
+    setTimeout(function(){
+      expect($scope.selectedPeers).toBeDefined();
+      expect($scope.selectedPeersIDs).toBeDefined();
+      expect($scope.selectedCount).toBeDefined();
+    }, 1000);
+
+    done();
+  });
+
+  it('compiles with a shareLinkPromise that resolves', function (done) {
+    $scope.shareLinkPromise = {
+      then: function (resolve, reject) {
+        setTimeout(resolve("test"), 1000);
+      }
+    }
+    createController();
+
+    setTimeout(function(){
+      expect($scope.shareLink.loading).toBe(true);
+      expect($scope.shareLink.url).not.toBeDefined();
+      setTimeout(function () {
+        expect($scope.shareLink.url).toBe("test");
+      }, 1000);
+    }, 1000);
+    done();
+  });
+
+
+  it('compiles with a shareLinkPromise that doesn\'t resolve', function (done) {
+    $scope.shareLinkPromise = {
+      then: function (resolve, reject) {
+        setTimeout(reject(), 1000);
+      }
+    }
+    createController();
+
+    setTimeout(function(){
+      expect($scope.shareLink.loading).toBe(true);
+      setTimeout(function () {
+        expect($scope.shareLink).not.toBeDefined();
+      }, 1000);
+    }, 1000);
+    done();
+  });
+
+  it('can select and submit a single dialog without confirmed type', function (done) {
+    createController();
+
+    $scope.dialogSelect("dialogX");
+
+    expect($promiseData).not.toBeDefined();
+    expect($promiseFlag).toBe(true);
+
+    done();
+  });
+
+  it('can select and submit a single dialog with confirmed type', function (done) {
+    createController();
+
+    $scope.confirm_type = "INVITE_TO_GROUP";
+    $scope.dialogSelect("dialogX");
+
+    var expected = {
+      type: "INVITE_TO_GROUP",
+      peer_id: "X",
+      peer_data: "Xpeer"
+    };
+
+    expect($promiseData).toEqual(expected);
+    expect($promiseFlag).toBe(true);
+
+    done();
+  });
+
+  it('can select a dialog', function (done) {
+    createController();
+
+    $scope.multiSelect = true;
+    $scope.dialogSelect("dialogX");
+
+    var expected = ["X"];
+
+    expect($scope.selectedPeers["X"]).toBe("Xpeer");
+    expect($scope.selectedCount).toBe(1);
+    expect($scope.selectedPeerIDs).toEqual(expected);
+
+    done();
+  });
+
+  it('can select multiple dialogs', function (done) {
+    createController();
+
+    $scope.multiSelect = true;
+    $scope.dialogSelect("dialogX");
+    $scope.dialogSelect("dialogZ");
+    $scope.dialogSelect("dialogY");
+
+    var expected = ["Y", "Z", "X"];
+
+    expect($scope.selectedCount).toBe(3);
+    expect($scope.selectedPeerIDs).toEqual(expected);
+
+    done();
+  });
+
+  it('can unselect a dialog', function (done) {
+    createController();
+
+    $scope.multiSelect = true;
+    $scope.selectedCount = 1;
+    $scope.selectedPeers["Y"] = "aYPeer";
+    $scope.selectedPeerIDs.unshift("Y");
+
+    $scope.dialogSelect("dialogY");
+
+    var expected = [];
+
+    expect($scope.selectedPeers["Y"]).not.toBeDefined()
+    expect($scope.selectedCount).toBe(0);
+    expect($scope.selectedPeerIDs).toEqual(expected);
+
+    done();
+  });
+
+  it('can select multiple dialogs', function (done) {
+    createController();
+
+    $scope.multiSelect = true;
+    $scope.dialogSelect("dialogX");
+    $scope.dialogSelect("dialogZ");
+    $scope.dialogSelect("dialogY");
+    $scope.dialogSelect("dialogZ");
+
+    var expected = ["Y", "X"];
+
+    expect($scope.selectedCount).toBe(2);
+    expect($scope.selectedPeerIDs).toEqual(expected);
+
+    done();
+  });
+
+  it('can\'t submit a empty set of dialogs', function (done) {
+    createController();
+
+    expect($scope.submitSelected()).not.toBeDefined();
+
+    done();
+  });
+
+
+  it('can submit one dialog', function (done) {
+    createController();
+
+    $scope.selectedCount = 1;
+    $scope.selectedPeers["test"] = "peer";
+    var expected = ["Ptest"];
+    expect($scope.submitSelected()).toEqual(expected);
+
+    done();
+  });
+
+
+  it('can submit multiple dialogs', function (done) {
+    createController();
+
+    $scope.selectedCount = 3;
+    $scope.selectedPeers["test1"] = $scope.selectedPeers["test2"] = $scope.selectedPeers["test4"] = "peer";
+
+    var expected = ["Ptest4", "Ptest2" ,"Ptest1"];
+    expect($scope.submitSelected()).toEqual(expected);
+
+    done();
+  });
+
+  it('can toggle', function (done) {
+    createController();
+
+    var broadcastFlag = '';
+    $scope.$broadcast = function (input) { broadcastFlag = input; };
+
+    $scope.toggleSearch();
+    expect(broadcastFlag).toBe('dialogs_search_toggle');
+
+    done();
+  });
+});

--- a/test/unit/PeerSelectControllerSpec.js
+++ b/test/unit/PeerSelectControllerSpec.js
@@ -1,6 +1,6 @@
 describe('PeerSelectController', function () {
   var $controller, $scope, $q, $mod, $APManager, $EService;
-  var createController;
+  var createController, timeoutTime;
   var $promiseData, $promise, $promiseFlag;
 
   beforeEach(module('myApp.controllers'));
@@ -13,6 +13,8 @@ describe('PeerSelectController', function () {
         return arr;
       }
     };
+
+    timeoutTime = 1000;
 
     $APManager = {
       getPeerString: function (str){
@@ -72,7 +74,7 @@ describe('PeerSelectController', function () {
       expect($scope.selectedPeers).toBeDefined();
       expect($scope.selectedPeersIDs).toBeDefined();
       expect($scope.selectedCount).toBeDefined();
-    }, 1000);
+    }, timeoutTime);
 
     done();
   });
@@ -80,7 +82,7 @@ describe('PeerSelectController', function () {
   it('compiles with a shareLinkPromise that resolves', function (done) {
     $scope.shareLinkPromise = {
       then: function (resolve, reject) {
-        setTimeout(resolve("test"), 1000);
+        setTimeout(resolve("test"), timeoutTime);
       }
     }
     createController();
@@ -90,8 +92,8 @@ describe('PeerSelectController', function () {
       expect($scope.shareLink.url).not.toBeDefined();
       setTimeout(function () {
         expect($scope.shareLink.url).toBe("test");
-      }, 1000);
-    }, 1000);
+      }, timeoutTime);
+    }, timeoutTime);
     done();
   });
 
@@ -99,7 +101,7 @@ describe('PeerSelectController', function () {
   it('compiles with a shareLinkPromise that doesn\'t resolve', function (done) {
     $scope.shareLinkPromise = {
       then: function (resolve, reject) {
-        setTimeout(reject(), 1000);
+        setTimeout(reject(), timeoutTime);
       }
     }
     createController();
@@ -108,8 +110,8 @@ describe('PeerSelectController', function () {
       expect($scope.shareLink.loading).toBe(true);
       setTimeout(function () {
         expect($scope.shareLink).not.toBeDefined();
-      }, 1000);
-    }, 1000);
+      }, timeoutTime);
+    }, timeoutTime);
     done();
   });
 


### PR DESCRIPTION
Part of Issue #1354.
This pull request will improve the test scores of the controller.js as follows:


|             | % Statements | % Branch | % Functions | % Lines |
|:-----------:|:------------:|:--------:|:-------------:|:---------:|
|  Currently  |      3.5     |     0    |    0.36     |   3.52  |
| After Merge |      5.61    |    1.16  |    2.88     |   5.64  |

This pull request fully tests the ChangeLogModalController, AppFooterController and PeerSelectController.
If a certain style is demanded for creating tests, then we will adapt the test to conform with the demanded style.
This is also the reason that this pull request tests some of the smaller controllers, in case changes are needed.