### PR TITLE
Added close button to About section on Login page

### DIFF
--- a/app/less/app.less
+++ b/app/less/app.less
@@ -1076,6 +1076,7 @@ a.tg_radio_on:hover i.icon-radio {
     font-size: 15px;
     font-weight: bold;
     text-align: left;
+    display: inline-block;
   }
 
   p {

--- a/app/partials/desktop/login.html
+++ b/app/partials/desktop/login.html
@@ -133,7 +133,7 @@
 
     <div ng-switch="about.shown">
       <div ng-switch-when="true" class="login_footer_about_wrap" my-scroll-to-on="$init">
-        <h3 my-i18n="login_about_title"></h3>
+        <h3 my-i18n="login_about_title"></h3> <small><a ng-click="about.shown = false" my-i18n="modal_close"></a></small>
         <p my-i18n="login_about_desc1_md"></p>
         <p my-i18n="login_about_desc2_md"></p>
         <p my-i18n="login_about_desc3_md">

--- a/app/partials/mobile/login.html
+++ b/app/partials/mobile/login.html
@@ -143,7 +143,7 @@
 
     <div ng-switch="about.shown">
       <div ng-switch-when="true" class="login_footer_about_wrap" my-scroll-to-on="$init">
-        <h3 my-i18n="login_about_title"></h3>
+        <h3 my-i18n="login_about_title"></h3> <small><a ng-click="about.shown = false" my-i18n="modal_close"></a></small>
         <p my-i18n="login_about_desc1_md"></p>
         <p my-i18n="login_about_desc2_md"></p>
         <p my-i18n="login_about_desc3_md">


### PR DESCRIPTION
Fixes #1357

Added a close button to both mobile and desktop partial to close the "About" section on Login page.
![image](https://cloud.githubusercontent.com/assets/5207258/23910091/e5cc3bc0-08d8-11e7-99a6-b926da876909.png)

