### PR TITLE
Renamed 'hasOnlick' to 'hasOnclick', added to StandardJS globals

### DIFF
--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -6,7 +6,7 @@
  */
 
 'use strict'
-/* global Config, location, templateUrl, onContentLoaded, tsNow, cancelEvent, safeReplaceObject, dT, SearchIndexManager, setZeroTimeout, versionCompare, calcImageInBox, getSelectedText, SVGElement  */
+/* global Config, location, templateUrl, onContentLoaded, tsNow, cancelEvent, safeReplaceObject, dT, SearchIndexManager, setZeroTimeout, versionCompare, calcImageInBox, getSelectedText, SVGElement, hasOnclick  */
 
 /* Controllers */
 
@@ -1666,7 +1666,7 @@ angular.module('myApp.controllers', ['myApp.i18n'])
             target.className.indexOf('im_message_body') != -1) {
             break
           }
-          if (target.tagName == 'A' || hasOnlick(target)) {
+          if (target.tagName == 'A' || hasOnclick(target)) {
             return false
           }
           target = target.parentNode

--- a/app/js/directives.js
+++ b/app/js/directives.js
@@ -6,7 +6,7 @@
  */
 
 'use strict'
-/* global Config, templateUrl, onContentLoaded, cancelEvent, dT, setZeroTimeout calcImageInBox, getSelectedText,Scroller, setFieldSelection, scrollToNode, EmojiTooltip, EmojiPanel, MessageComposer, checkDragEvent, checkClick, Image, Clipboard, EmojiHelper, encodeEntities, FB, twttr, gapi, isInDOM */
+/* global Config, templateUrl, onContentLoaded, cancelEvent, dT, setZeroTimeout calcImageInBox, getSelectedText,Scroller, setFieldSelection, scrollToNode, EmojiTooltip, EmojiPanel, MessageComposer, checkDragEvent, checkClick, Image, Clipboard, EmojiHelper, encodeEntities, FB, twttr, gapi, isInDOM, hasOnclick */
 
 /* Directives */
 
@@ -2848,7 +2848,7 @@ angular.module('myApp.directives', ['myApp.filters'])
         }
       }
 
-      if (element[0].tagName == 'A' && !hasOnlick(element[0])) {
+      if (element[0].tagName == 'A' && !hasOnclick(element[0])) {
         element.on('click', function () {
           if (peerID > 0) {
             AppUsersManager.openUser(peerID, override)

--- a/app/js/lib/utils.js
+++ b/app/js/lib/utils.js
@@ -62,7 +62,7 @@ function cancelEvent (event) {
   return false
 }
 
-function hasOnlick (element) {
+function hasOnclick (element) {
   if (element.onclick ||
     element.getAttribute('ng-click')) {
     return true


### PR DESCRIPTION
Small typo in function name, 'hasOnlick' instead of 'hasOnclick'. In the function itself onclick is written without a capital therefore did not place the capital in the function name. Can be changed to 'hasOnClick' if requested.