### PR TITLE
Make filter-tests timezone-independant

### DIFF
--- a/test/unit/filters/myDateFilterSpec.js
+++ b/test/unit/filters/myDateFilterSpec.js
@@ -10,11 +10,15 @@ describe('myDate filter', function () {
 
   beforeEach(function () {
     this.myDateFilter = this.$filter('myDate')
+
+    // https://stackoverflow.com/questions/4676195/why-do-i-need-to-multiply-unix-timestamps-by-1000-in-javascript
+    this.miliSecondsToSeconds = 1000
+    this.dateFilter = this.$filter('date')
   })
 
   it('can create a date based on timestamp', function () {
     var input = 1222222222
-    var expected = 'Wednesday, September 24, 2008'
+    var expected = this.dateFilter(input * this.miliSecondsToSeconds, 'fullDate') // For CEST: 'Wednesday, September 24, 2008'
     var result = this.myDateFilter(input)
 
     expect(result).toBe(expected)
@@ -22,7 +26,7 @@ describe('myDate filter', function () {
 
   it('can recollect a date based on timestamp', function () {
     var input = 12111114111
-    var expected = 'Thursday, October 15, 2353'
+    var expected = this.dateFilter(input * this.miliSecondsToSeconds, 'fullDate') // For CEST: 'Thursday, October 15, 2353'
     var result1 = this.myDateFilter(input)
 
     expect(result1).toBe(expected)

--- a/test/unit/filters/timeFilterSpec.js
+++ b/test/unit/filters/timeFilterSpec.js
@@ -8,6 +8,12 @@ describe('time filter', function () {
     this.$filter = _$filter_
   }))
 
+  beforeEach(function () {
+    // https://stackoverflow.com/questions/4676195/why-do-i-need-to-multiply-unix-timestamps-by-1000-in-javascript
+    this.miliSecondsToSeconds = 1000
+    this.dateFilter = this.$filter('date')
+  })
+
   describe('on the mobile website', function () {
     beforeEach(function () {
       Config.Mobile = true
@@ -16,7 +22,7 @@ describe('time filter', function () {
 
     it('can create a short time based on timestamp', function () {
       var input = 1222
-      var expected = '1:20 AM'
+      var expected = this.dateFilter(input * this.miliSecondsToSeconds, 'shortTime') // For CEST: '1:20 AM'
       var result = this.timeFilter(input)
 
       expect(result).toBe(expected)
@@ -24,7 +30,7 @@ describe('time filter', function () {
 
     it('can recollect a short time based on timestamp', function () {
       var input = 121155
-      var expected = '10:39 AM'
+      var expected = this.dateFilter(input * this.miliSecondsToSeconds, 'shortTime') // For CEST: '10:39 AM'
       var result1 = this.timeFilter(input)
 
       expect(result1).toBe(expected)
@@ -43,7 +49,7 @@ describe('time filter', function () {
 
     it('can create a medium-size time based on timestamp', function () {
       var input = 1222
-      var expected = '1:20:22 AM'
+      var expected = this.dateFilter(input * this.miliSecondsToSeconds, 'mediumTime') // For CEST: '1:20:22 AM'
       var result = this.timeFilter(input)
 
       expect(result).toBe(expected)
@@ -51,7 +57,7 @@ describe('time filter', function () {
 
     it('can recollect a medium-size time on timestamp', function () {
       var input = 121155
-      var expected = '10:39:15 AM'
+      var expected = this.dateFilter(input * this.miliSecondsToSeconds, 'mediumTime') // For CEST: '10:39:15 AM'
       var result1 = this.timeFilter(input)
 
       expect(result1).toBe(expected)


### PR DESCRIPTION
The tests from #1393 had string-solutions for some tests 
However, these tests were fixed for one time-zone: CEST
This created problems for CI frameworks on different timezones (as seen in https://travis-ci.org/bartist/webogram/builds/227096263)

This PR will fix these problems (https://travis-ci.org/bartist/webogram/builds/227108224)