### PR TITLE
Change color of ChromeOS App window to blue. Fix #1403

### DIFF
--- a/app/js/background.js
+++ b/app/js/background.js
@@ -14,6 +14,6 @@ chrome.app.runtime.onLaunched.addListener(function (launchData) {
     },
     minWidth: 320,
     minHeight: 400,
-    frame: 'chrome'
+    frame: { color: "#5682a3" }
   })
 })


### PR DESCRIPTION
[UI Improvement] Changes color of Chrome OS app window frame to blue.

Before:
![nocolor](https://cloud.githubusercontent.com/assets/13156162/25864724/7c55e51c-34be-11e7-843c-594fa5da81ab.png)

After:
![color](https://cloud.githubusercontent.com/assets/13156162/25864737/86003c70-34be-11e7-9e97-549080a7290b.png)

