### PR TITLE
Added tests to improve Controller test coverage to over 10%

### DIFF
--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -4455,9 +4455,11 @@ angular.module('myApp.controllers', ['myApp.i18n'])
         AppUsersManager.saveApiUser(user)
         $modalInstance.close()
       }, function (error) {
-        if (error.type == 'USERNAME_NOT_MODIFIED') {
-          error.handled = true
-          $modalInstance.close()
+        switch (error.type) {
+          case 'USERNAME_NOT_MODIFIED':
+            error.handled = true
+            $modalInstance.close()
+            break
         }
       })['finally'](function () {
         delete $scope.profile.updating
@@ -4470,9 +4472,9 @@ angular.module('myApp.controllers', ['myApp.i18n'])
         return
       }
       MtpApiManager.invokeApi('account.checkUsername', {
-        username: newVal || ''
+        username: newVal
       }).then(function (valid) {
-        if ($scope.profile.username != newVal) {
+        if ($scope.profile.username !== newVal) {
           return
         }
         if (valid) {
@@ -4481,7 +4483,7 @@ angular.module('myApp.controllers', ['myApp.i18n'])
           $scope.checked = {error: true}
         }
       }, function (error) {
-        if ($scope.profile.username != newVal) {
+        if ($scope.profile.username !== newVal) {
           return
         }
         switch (error.type) {

--- a/test/unit/controllers/CountrySelectModalControllerSpec.js
+++ b/test/unit/controllers/CountrySelectModalControllerSpec.js
@@ -25,8 +25,29 @@ describe('CountrySelectModalController', function () {
 
   beforeEach(function () {
     this.ConfigCountryCodes = Config.CountryCodes
-    this.NL_COUNTRY_CODE = 'NL Netherlands +31'
-    this.VATICAN_COUNTRY_CODE = 'VA Vatican City +39 06 698 +379'
+    this.testData = {
+      singleCode: {
+        countryCode: ['NL', 'country_select_modal_country_nl', '+31'],
+        countryCode_full: 'NL Netherlands +31',
+        countryPhoneSets: [{ name: 'Netherlands', code: '+31' }]
+      },
+      multipleCode: {
+        countryCode: ['VA', 'country_select_modal_country_va', '+39 06 698', '+379'],
+        countryCode_full: 'VA Vatican City +39 06 698 +379',
+        countryPhoneSets: [{ name: 'Vatican City', code: '+39 06 698' }, { name: 'Vatican City', code: '+379' }]
+      },
+      multipleCode2: {
+        countryCode: ['AB', 'country_select_modal_country_ab', '+7 840', '+7 940', '+995 44'],
+        countryCode_full: 'AB Abkhazia +7 840 +7 940 +995 44',
+        countryPhoneSets: [{ name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }]
+      },
+      allSetsSorted: function () {
+        return [].concat(this.multipleCode2.countryPhoneSets, this.singleCode.countryPhoneSets, this.multipleCode.countryPhoneSets)
+      },
+      allSetsUnsorted: function () {
+        return [].concat(this.singleCode.countryPhoneSets, this.multipleCode2.countryPhoneSets, this.multipleCode.countryPhoneSets)
+      }
+    }
   })
 
   afterEach(function () {
@@ -37,8 +58,8 @@ describe('CountrySelectModalController', function () {
   // In order to mock Config data
 
   it('initiates Country to select', function (done) {
-    Config.CountryCodes = [['NL', 'country_select_modal_country_nl', '+31']]
-    var expected = this.NL_COUNTRY_CODE
+    Config.CountryCodes = [this.testData.singleCode.countryCode]
+    var expected = this.testData.singleCode.countryCode_full
 
     this.createController()
 
@@ -47,8 +68,8 @@ describe('CountrySelectModalController', function () {
   })
 
   it('initiates Countriy to select with 2 (or more) country codes', function (done) {
-    Config.CountryCodes = [['VA', 'country_select_modal_country_va', '+39 06 698', '+379']]
-    var expected = this.VATICAN_COUNTRY_CODE
+    Config.CountryCodes = [this.testData.multipleCode.countryCode]
+    var expected = this.testData.multipleCode.countryCode_full
 
     this.createController()
 
@@ -57,9 +78,9 @@ describe('CountrySelectModalController', function () {
   })
 
   it('initiates Countries to select', function (done) {
-    Config.CountryCodes = [['NL', 'country_select_modal_country_nl', '+31'], ['VA', 'country_select_modal_country_va', '+39 06 698', '+379']]
-    var expected1 = this.NL_COUNTRY_CODE
-    var expected2 = this.VATICAN_COUNTRY_CODE
+    Config.CountryCodes = [this.testData.singleCode.countryCode, this.testData.multipleCode.countryCode]
+    var expected1 = this.testData.singleCode.countryCode_full
+    var expected2 = this.testData.multipleCode.countryCode_full
 
     this.createController()
 
@@ -70,7 +91,7 @@ describe('CountrySelectModalController', function () {
 
   describe('(after initiation)', function () {
     beforeEach(function () {
-      Config.CountryCodes = [['NL', 'country_select_modal_country_nl', '+31'], ['AB', 'country_select_modal_country_ab', '+7 840', '+7 940', '+995 44'], ['VA', 'country_select_modal_country_va', '+39 06 698', '+379']]
+      Config.CountryCodes = [this.testData.singleCode.countryCode, this.testData.multipleCode2.countryCode, this.testData.multipleCode.countryCode]
       this.createController()
     })
 
@@ -82,7 +103,7 @@ describe('CountrySelectModalController', function () {
 
     it('creates a sorted list of all selectable countries', function (done) {
       this.$rootScope.$digest()
-      var expected = [{ name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }, { name: 'Netherlands', code: '+31' }, { name: 'Vatican City', code: '+39 06 698' }, { name: 'Vatican City', code: '+379' }]
+      var expected = this.testData.allSetsSorted()
 
       expect(this.$scope.countries).toEqual(expected)
       done()
@@ -92,7 +113,7 @@ describe('CountrySelectModalController', function () {
       this.$rootScope.$digest()
       this.$scope.search.query = ''
       this.$rootScope.$digest()
-      var expected = [{ name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }, { name: 'Netherlands', code: '+31' }, { name: 'Vatican City', code: '+39 06 698' }, { name: 'Vatican City', code: '+379' }]
+      var expected = this.testData.allSetsSorted()
 
       expect(this.$scope.countries).toEqual(expected)
       done()
@@ -105,12 +126,12 @@ describe('CountrySelectModalController', function () {
       })
 
       it('creates a sorted list of all countries containing the input', function (done) {
-        var expected = [{ name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }, { name: 'Netherlands', code: '+31' }, { name: 'Vatican City', code: '+39 06 698' }, { name: 'Vatican City', code: '+379' }]
+        var expected = this.testData.allSetsSorted()
 
         expect(this.$scope.countries).toEqual(expected)
 
         this.$rootScope.$digest()
-        expected = [{ name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }]
+        expected = this.testData.multipleCode2.countryPhoneSets
 
         expect(this.$scope.countries).toEqual(expected)
         done()
@@ -121,18 +142,18 @@ describe('CountrySelectModalController', function () {
         this.$scope.search.query = ''
         this.$rootScope.$digest()
 
-        var expected = [{ name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }, { name: 'Netherlands', code: '+31' }, { name: 'Vatican City', code: '+39 06 698' }, { name: 'Vatican City', code: '+379' }]
+        var expected = this.testData.allSetsSorted()
 
         expect(this.$scope.countries).toEqual(expected)
         done()
       })
 
-      it('restore the original list when the input is deleted', function (done) {
+      it('restore the original list when the input is changed', function (done) {
         this.$rootScope.$digest()
         this.$scope.search.query = 'Ne'
         this.$rootScope.$digest()
 
-        var expected = [{ name: 'Netherlands', code: '+31' }]
+        var expected = this.testData.singleCode.countryPhoneSets
 
         expect(this.$scope.countries).toEqual(expected)
         done()
@@ -151,7 +172,7 @@ describe('CountrySelectModalController', function () {
 
       it('creates a list of all selectable countries', function (done) {
         this.$rootScope.$digest()
-        var expected = [{ name: 'Netherlands', code: '+31' }, { name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }, { name: 'Vatican City', code: '+39 06 698' }, { name: 'Vatican City', code: '+379' }]
+        var expected = this.testData.allSetsUnsorted()
 
         expect(this.$scope.countries).toEqual(expected)
         done()

--- a/test/unit/controllers/CountrySelectModalControllerSpec.js
+++ b/test/unit/controllers/CountrySelectModalControllerSpec.js
@@ -10,13 +10,12 @@ describe('CountrySelectModalController', function () {
     this._ = ___
 
     this.$scope = _$rootScope_.$new()
-    var scope = this.$scope
     this.createController = function () {
       this.$controller('CountrySelectModalController', {
-        $scope: scope,
+        $scope: this.$scope,
         $modalInstance: {},
-        $rootScope: _$rootScope_,
-        _: ___
+        $rootScope: this.$rootScope,
+        _: this._
       })
     }
 

--- a/test/unit/controllers/CountrySelectModalControllerSpec.js
+++ b/test/unit/controllers/CountrySelectModalControllerSpec.js
@@ -1,5 +1,5 @@
 'use strict'
-/* global describe, it, inject, expect, beforeEach */
+/* global describe, it, inject, expect, beforeEach, spyOn, jasmine, Config, SearchIndexManager */
 
 describe('CountrySelectModalController', function () {
   beforeEach(module('myApp.controllers'))
@@ -21,7 +21,7 @@ describe('CountrySelectModalController', function () {
     }
 
     // Spy on IndexObject
-    spyOn(SearchIndexManager, "indexObject").and.callThrough()
+    spyOn(SearchIndexManager, 'indexObject').and.callThrough()
   }))
 
   // define tests
@@ -35,7 +35,7 @@ describe('CountrySelectModalController', function () {
 
     this.createController()
 
-    expect(SearchIndexManager.indexObject).toHaveBeenCalledWith(0, expected, jasmine.any(Object));
+    expect(SearchIndexManager.indexObject).toHaveBeenCalledWith(0, expected, jasmine.any(Object))
     done()
   })
 
@@ -45,7 +45,7 @@ describe('CountrySelectModalController', function () {
 
     this.createController()
 
-    expect(SearchIndexManager.indexObject).toHaveBeenCalledWith(0, expected, jasmine.any(Object));
+    expect(SearchIndexManager.indexObject).toHaveBeenCalledWith(0, expected, jasmine.any(Object))
     done()
   })
 
@@ -56,11 +56,10 @@ describe('CountrySelectModalController', function () {
 
     this.createController()
 
-    expect(SearchIndexManager.indexObject).toHaveBeenCalledWith(0, expected1, jasmine.any(Object));
-    expect(SearchIndexManager.indexObject).toHaveBeenCalledWith(1, expected2, jasmine.any(Object));
+    expect(SearchIndexManager.indexObject).toHaveBeenCalledWith(0, expected1, jasmine.any(Object))
+    expect(SearchIndexManager.indexObject).toHaveBeenCalledWith(1, expected2, jasmine.any(Object))
     done()
   })
-
 
   describe('(after initiation)', function () {
     beforeEach(function () {
@@ -104,14 +103,13 @@ describe('CountrySelectModalController', function () {
         expect(this.$scope.countries).toEqual(expected)
 
         this.$rootScope.$digest()
-        expected =[{ name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }]
+        expected = [{ name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }]
 
         expect(this.$scope.countries).toEqual(expected)
         done()
       })
 
       it('restore the original list when the input is deleted', function (done) {
-
         this.$rootScope.$digest()
         this.$scope.search.query = ''
         this.$rootScope.$digest()
@@ -123,7 +121,6 @@ describe('CountrySelectModalController', function () {
       })
 
       it('restore the original list when the input is deleted', function (done) {
-
         this.$rootScope.$digest()
         this.$scope.search.query = 'Ne'
         this.$rootScope.$digest()

--- a/test/unit/controllers/CountrySelectModalControllerSpec.js
+++ b/test/unit/controllers/CountrySelectModalControllerSpec.js
@@ -109,6 +109,30 @@ describe('CountrySelectModalController', function () {
         expect(this.$scope.countries).toEqual(expected)
         done()
       })
+
+      it('restore the original list when the input is deleted', function (done) {
+
+        this.$rootScope.$digest()
+        this.$scope.search.query = ''
+        this.$rootScope.$digest()
+
+        var expected = [{ name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }, { name: 'Netherlands', code: '+31' }, { name: 'Vatican City', code: '+39 06 698' }, { name: 'Vatican City', code: '+379' }]
+
+        expect(this.$scope.countries).toEqual(expected)
+        done()
+      })
+
+      it('restore the original list when the input is deleted', function (done) {
+
+        this.$rootScope.$digest()
+        this.$scope.search.query = 'Ne'
+        this.$rootScope.$digest()
+
+        var expected = [{ name: 'Netherlands', code: '+31' }]
+
+        expect(this.$scope.countries).toEqual(expected)
+        done()
+      })
     })
 
     describe(', when no sorting is available,', function () {

--- a/test/unit/controllers/CountrySelectModalControllerSpec.js
+++ b/test/unit/controllers/CountrySelectModalControllerSpec.js
@@ -1,0 +1,128 @@
+'use strict'
+/* global describe, it, inject, expect, beforeEach */
+
+describe('CountrySelectModalController', function () {
+  beforeEach(module('myApp.controllers'))
+
+  beforeEach(inject(function (_$controller_, _$rootScope_, ___) {
+    this.$controller = _$controller_
+    this.$rootScope = _$rootScope_
+    this._ = ___
+
+    this.$scope = _$rootScope_.$new()
+    var scope = this.$scope
+    this.createController = function () {
+      this.$controller('CountrySelectModalController', {
+        $scope: scope,
+        $modalInstance: {},
+        $rootScope: _$rootScope_,
+        _: ___
+      })
+    }
+
+    // Spy on IndexObject
+    spyOn(SearchIndexManager, "indexObject").and.callThrough()
+  }))
+
+  // define tests
+
+  // The tests before controller initiation.
+  // In order to mock Config data
+
+  it('initiates Country to select', function (done) {
+    Config.CountryCodes = [['NL', 'country_select_modal_country_nl', '+31']]
+    var expected = 'NL Netherlands +31'
+
+    this.createController()
+
+    expect(SearchIndexManager.indexObject).toHaveBeenCalledWith(0, expected, jasmine.any(Object));
+    done()
+  })
+
+  it('initiates Countriy to select with 2 (or more) country codes', function (done) {
+    Config.CountryCodes = [['VA', 'country_select_modal_country_va', '+39 06 698', '+379']]
+    var expected = 'VA Vatican City +39 06 698 +379'
+
+    this.createController()
+
+    expect(SearchIndexManager.indexObject).toHaveBeenCalledWith(0, expected, jasmine.any(Object));
+    done()
+  })
+
+  it('initiates Countries to select', function (done) {
+    Config.CountryCodes = [['NL', 'country_select_modal_country_nl', '+31'], ['VA', 'country_select_modal_country_va', '+39 06 698', '+379']]
+    var expected1 = 'NL Netherlands +31'
+    var expected2 = 'VA Vatican City +39 06 698 +379'
+
+    this.createController()
+
+    expect(SearchIndexManager.indexObject).toHaveBeenCalledWith(0, expected1, jasmine.any(Object));
+    expect(SearchIndexManager.indexObject).toHaveBeenCalledWith(1, expected2, jasmine.any(Object));
+    done()
+  })
+
+
+  describe('(after initiation)', function () {
+    beforeEach(function () {
+      Config.CountryCodes = [['NL', 'country_select_modal_country_nl', '+31'], ['AB', 'country_select_modal_country_ab', '+7 840', '+7 940', '+995 44'], ['VA', 'country_select_modal_country_va', '+39 06 698', '+379']]
+      this.createController()
+    })
+
+    it('initiates the right values', function (done) {
+      expect(this.$scope.search).toEqual({})
+      expect(this.$scope.slice).toEqual({limit: 20, limitDelta: 20})
+      done()
+    })
+
+    it('creates a sorted list of all selectable countries', function (done) {
+      this.$rootScope.$digest()
+      var expected = [{ name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }, { name: 'Netherlands', code: '+31' }, { name: 'Vatican City', code: '+39 06 698' }, { name: 'Vatican City', code: '+379' }]
+
+      expect(this.$scope.countries).toEqual(expected)
+      done()
+    })
+
+    it('creates a sorted list of all selectable countries for an empty string-input', function (done) {
+      this.$rootScope.$digest()
+      this.$scope.search.query = ''
+      this.$rootScope.$digest()
+      var expected = [{ name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }, { name: 'Netherlands', code: '+31' }, { name: 'Vatican City', code: '+39 06 698' }, { name: 'Vatican City', code: '+379' }]
+
+      expect(this.$scope.countries).toEqual(expected)
+      done()
+    })
+
+    describe(', when an input is given,', function () {
+      beforeEach(function () {
+        this.$rootScope.$digest()
+        this.$scope.search.query = 'A'
+      })
+
+      it('creates a sorted list of all countries containing the input', function (done) {
+        var expected = [{ name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }, { name: 'Netherlands', code: '+31' }, { name: 'Vatican City', code: '+39 06 698' }, { name: 'Vatican City', code: '+379' }]
+
+        expect(this.$scope.countries).toEqual(expected)
+
+        this.$rootScope.$digest()
+        expected =[{ name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }]
+
+        expect(this.$scope.countries).toEqual(expected)
+        done()
+      })
+    })
+
+    describe(', when no sorting is available,', function () {
+      beforeEach(function () {
+        String.prototype.localeCompare = null
+      })
+
+      it('creates a list of all selectable countries', function (done) {
+        this.$rootScope.$digest()
+        var expected = [{ name: 'Netherlands', code: '+31' }, { name: 'Abkhazia', code: '+7 840' }, { name: 'Abkhazia', code: '+7 940' }, { name: 'Abkhazia', code: '+995 44' }, { name: 'Vatican City', code: '+39 06 698' }, { name: 'Vatican City', code: '+379' }]
+
+        expect(this.$scope.countries).toEqual(expected)
+        done()
+      })
+    })
+  })
+})

--- a/test/unit/controllers/CountrySelectModalControllerSpec.js
+++ b/test/unit/controllers/CountrySelectModalControllerSpec.js
@@ -1,5 +1,5 @@
 'use strict'
-/* global describe, it, inject, expect, beforeEach, spyOn, jasmine, Config, SearchIndexManager */
+/* global describe, it, inject, expect, beforeEach, afterEach, spyOn, jasmine, Config, SearchIndexManager */
 
 describe('CountrySelectModalController', function () {
   beforeEach(module('myApp.controllers'))
@@ -20,18 +20,25 @@ describe('CountrySelectModalController', function () {
       })
     }
 
-    // Spy on IndexObject
     spyOn(SearchIndexManager, 'indexObject').and.callThrough()
   }))
 
-  // define tests
+  beforeEach(function () {
+    this.ConfigCountryCodes = Config.CountryCodes
+    this.NL_COUNTRY_CODE = 'NL Netherlands +31'
+    this.VATICAN_COUNTRY_CODE = 'VA Vatican City +39 06 698 +379'
+  })
+
+  afterEach(function () {
+    Config.CountryCodes = this.ConfigCountryCodes
+  })
 
   // The tests before controller initiation.
   // In order to mock Config data
 
   it('initiates Country to select', function (done) {
     Config.CountryCodes = [['NL', 'country_select_modal_country_nl', '+31']]
-    var expected = 'NL Netherlands +31'
+    var expected = this.NL_COUNTRY_CODE
 
     this.createController()
 
@@ -41,7 +48,7 @@ describe('CountrySelectModalController', function () {
 
   it('initiates Countriy to select with 2 (or more) country codes', function (done) {
     Config.CountryCodes = [['VA', 'country_select_modal_country_va', '+39 06 698', '+379']]
-    var expected = 'VA Vatican City +39 06 698 +379'
+    var expected = this.VATICAN_COUNTRY_CODE
 
     this.createController()
 
@@ -51,8 +58,8 @@ describe('CountrySelectModalController', function () {
 
   it('initiates Countries to select', function (done) {
     Config.CountryCodes = [['NL', 'country_select_modal_country_nl', '+31'], ['VA', 'country_select_modal_country_va', '+39 06 698', '+379']]
-    var expected1 = 'NL Netherlands +31'
-    var expected2 = 'VA Vatican City +39 06 698 +379'
+    var expected1 = this.NL_COUNTRY_CODE
+    var expected2 = this.VATICAN_COUNTRY_CODE
 
     this.createController()
 
@@ -134,7 +141,12 @@ describe('CountrySelectModalController', function () {
 
     describe(', when no sorting is available,', function () {
       beforeEach(function () {
+        this.StringCompare = String.prototype.localeCompare
         String.prototype.localeCompare = null
+      })
+
+      afterEach(function () {
+        String.prototype.localeCompare = this.StringCompare
       })
 
       it('creates a list of all selectable countries', function (done) {

--- a/test/unit/controllers/ImportContactModalControllerSpec.js
+++ b/test/unit/controllers/ImportContactModalControllerSpec.js
@@ -54,25 +54,19 @@ describe('ImportContactModalController', function () {
       }
     }
 
-    var modalInstance = this.modalInstance
-    var AppUsersManager = this.AppUsersManager
-    var ErrorService = this.ErrorService
-    var PhonebookContactsService = this.PhonebookContactsService
-
     inject(function (_$controller_, _$rootScope_) {
       this.$controller = _$controller_
       this.$rootScope = _$rootScope_
 
       this.$scope = _$rootScope_.$new()
-      var scope = this.$scope
       this.createController = function () {
         this.$controller('ImportContactModalController', {
-          $scope: scope,
-          $modalInstance: modalInstance,
-          $rootScope: _$rootScope_,
-          AppUsersManager: AppUsersManager,
-          ErrorService: ErrorService,
-          PhonebookContactsService: PhonebookContactsService
+          $scope: this.$scope,
+          $modalInstance: this.modalInstance,
+          $rootScope: this.$rootScope,
+          AppUsersManager: this.AppUsersManager,
+          ErrorService: this.ErrorService,
+          PhonebookContactsService: this.PhonebookContactsService
         })
       }
     })

--- a/test/unit/controllers/ImportContactModalControllerSpec.js
+++ b/test/unit/controllers/ImportContactModalControllerSpec.js
@@ -1,0 +1,188 @@
+'use strict'
+/* global describe, it, inject, expect, beforeEach */
+
+describe('ImportContactModalController', function () {
+  beforeEach(module('myApp.controllers'))
+
+  beforeEach(inject(function (_$controller_, _$rootScope_) {
+    this.$controller = _$controller_
+    this.$rootScope = _$rootScope_
+
+    this.pcs = {
+      importSwitch: false,
+      isAvailable: function () {
+        return false
+      },
+      openPhonebookImport: function() {
+        if(this.importSwitch)
+          return this.importTrue
+        else
+          return this.importFalse
+      },
+      importFalse: {
+        result: {
+          then: function (f) {
+            f(false)
+          }
+        }
+      },
+      importTrue: {
+        result: {
+          then: function (f) {
+            f({0: 'dummy'})
+          }
+        }
+      }
+    }
+
+    var pcs = this.pcs
+
+    this.modalInst = {}
+    this.modalInst.dismiss = jasmine.createSpy('dismiss')
+    this.modalInst.close = jasmine.createSpy('close')
+    var mi = this.modalInst
+
+    var fin = {
+      finally: function (f) {
+        f()
+      }
+    }
+    this.randomID = 123456852
+    var rID = this.randomID
+    this.aum = {
+      importSwitch: false,
+      importContact: function (phone, first, last) {
+        this.input = {
+          phone: phone,
+          first: first,
+          last: last
+        }
+        if(this.importSwitch)
+          return this.importTrue
+        else
+          return this.importFalse
+      },
+      importFalse: {
+        then: function(f) {
+          f(null)
+          return this.finally
+        },
+        finally: fin
+      },
+      importTrue: {
+        then: function(f) {
+          f(rID)
+          return this.finally
+        },
+        finally: fin
+      }
+    }
+    var aum = this.aum
+
+    this.errs = {}
+    this.errs.show = jasmine.createSpy('show')
+    var errs = this.errs
+
+    this.$scope = _$rootScope_.$new()
+    var scope = this.$scope
+    this.createController = function () {
+      this.$controller('ImportContactModalController', {
+        $scope: scope,
+        $modalInstance: mi  ,
+        $rootScope: _$rootScope_,
+        AppUsersManager: aum,
+        ErrorService: errs,
+        PhonebookContactsService: pcs
+      })
+    }
+  }))
+
+  // define tests
+
+  it('can create a controller when no imported contacts are defined', function (done) {
+    this.createController()
+
+    expect(this.$scope.importContact).toEqual({})
+    done()
+  })
+
+  it('can create a controller when imported contacts are defined', function (done) {
+    this.$scope.importContact = { non_empty: true }
+    this.createController()
+    var expected =  { non_empty: true }
+
+    expect(this.$scope.importContact).toEqual(expected)
+    done()
+  })
+
+  describe('(when the controller is created), ',function () {
+    beforeEach(function (){
+      this.createController()
+    })
+
+    it('does nothing when no information was entered', function (done) {
+      this.$scope.doImport()
+
+      expect(this.$scope.progress).not.toBeDefined()
+
+      // no Phonenumber
+      this.$scope.importContact = {
+        first_name: 'bob'
+      }
+      expect(this.$scope.progress).not.toBeDefined()
+      done()
+    })
+
+    describe('when contact-information is added, it', function () {
+      beforeEach(function () {
+        this.$scope.importContact = {
+          phone: '+316132465798'
+        }
+      })
+
+      it('can handle phoneNumber that are not telegram users', function (done) {
+        this.$scope.doImport()
+
+        expect(this.errs.show).toHaveBeenCalledWith({ error: {code: 404, type: 'USER_NOT_USING_TELEGRAM'} })
+        expect(this.modalInst.close).toHaveBeenCalledWith(null)
+        expect(this.$scope.progress.enabled).not.toBeDefined()
+        done()
+      })
+
+      it('can import contacts that are telegram users', function (done) {
+        this.aum.importSwitch = true
+        this.$scope.doImport()
+
+        expect(this.errs.show).not.toHaveBeenCalled()
+        expect(this.modalInst.close).toHaveBeenCalledWith(this.randomID)
+        expect(this.$scope.progress.enabled).not.toBeDefined()
+        expect(this.aum.input).toEqual({phone: '+316132465798', first: '', last: ''})
+        done()
+      })
+
+      it('can handle contacts with first and last name', function (done) {
+        this.$scope.importContact.first_name = 'jan'
+        this.$scope.importContact.last_name = 'wandelaar'
+        this.$scope.doImport()
+
+        expect(this.aum.input).toEqual({phone: '+316132465798', first: 'jan', last: 'wandelaar'})
+        done()
+      })
+    })
+
+    it('can\'t import contacts from a phonebook if none were found', function (done) {
+      this.$scope.importPhonebook()
+
+      expect(this.modalInst.dismiss).toHaveBeenCalled()
+      done()
+    })
+
+    it('can import contacts from a phonebook', function (done) {
+      this.pcs.importSwitch = true
+      this.$scope.importPhonebook()
+
+      expect(this.modalInst.close).toHaveBeenCalledWith('dummy')
+      done()
+    })
+  })
+})

--- a/test/unit/controllers/ImportContactModalControllerSpec.js
+++ b/test/unit/controllers/ImportContactModalControllerSpec.js
@@ -1,5 +1,5 @@
 'use strict'
-/* global describe, it, inject, expect, beforeEach */
+/* global describe, it, inject, expect, beforeEach, jasmine */
 
 describe('ImportContactModalController', function () {
   beforeEach(module('myApp.controllers'))
@@ -13,11 +13,12 @@ describe('ImportContactModalController', function () {
       isAvailable: function () {
         return false
       },
-      openPhonebookImport: function() {
-        if(this.importSwitch)
+      openPhonebookImport: function () {
+        if (this.importSwitch) {
           return this.importTrue
-        else
+        } else {
           return this.importFalse
+        }
       },
       importFalse: {
         result: {
@@ -57,20 +58,21 @@ describe('ImportContactModalController', function () {
           first: first,
           last: last
         }
-        if(this.importSwitch)
+        if (this.importSwitch) {
           return this.importTrue
-        else
+        } else {
           return this.importFalse
+        }
       },
       importFalse: {
-        then: function(f) {
+        then: function (f) {
           f(null)
           return this.finally
         },
         finally: fin
       },
       importTrue: {
-        then: function(f) {
+        then: function (f) {
           f(rID)
           return this.finally
         },
@@ -88,7 +90,7 @@ describe('ImportContactModalController', function () {
     this.createController = function () {
       this.$controller('ImportContactModalController', {
         $scope: scope,
-        $modalInstance: mi  ,
+        $modalInstance: mi,
         $rootScope: _$rootScope_,
         AppUsersManager: aum,
         ErrorService: errs,
@@ -109,14 +111,14 @@ describe('ImportContactModalController', function () {
   it('can create a controller when imported contacts are defined', function (done) {
     this.$scope.importContact = { non_empty: true }
     this.createController()
-    var expected =  { non_empty: true }
+    var expected = { non_empty: true }
 
     expect(this.$scope.importContact).toEqual(expected)
     done()
   })
 
-  describe('(when the controller is created), ',function () {
-    beforeEach(function (){
+  describe('(when the controller is created), ', function () {
+    beforeEach(function () {
       this.createController()
     })
 

--- a/test/unit/controllers/PasswordRecoveryModalControllerSpec.js
+++ b/test/unit/controllers/PasswordRecoveryModalControllerSpec.js
@@ -30,23 +30,19 @@ describe('PasswordRecoveryModalController', function () {
       dismiss: jasmine.createSpy('dismiss')
     }
 
-    var PasswordManager = this.PasswordManager
-    var ErrorService = this.ErrorService
-    var modalInstance = this.modalInstance
-
     inject(function (_$controller_, _$rootScope_, ___) {
       this.$controller = _$controller_
-      var $scope = _$rootScope_.$new()
-      $scope.recovery = {}
-      this.$scope = $scope
+      this.$scope = _$rootScope_.$new()
+      this.$scope.recovery = {}
+
       this.$controller('PasswordRecoveryModalController', {
-        $scope: $scope,
+        $scope: this.$scope,
         $q: {},
         _: ___,
-        PasswordManager: PasswordManager,
+        PasswordManager: this.PasswordManager,
         MtpApiManager: {},
-        ErrorService: ErrorService,
-        $modalInstance: modalInstance
+        ErrorService: this.ErrorService,
+        $modalInstance: this.modalInstance
       })
     })
   })

--- a/test/unit/controllers/PasswordRecoveryModalControllerSpec.js
+++ b/test/unit/controllers/PasswordRecoveryModalControllerSpec.js
@@ -1,0 +1,116 @@
+'use strict'
+/* global describe, it, inject, expect, beforeEach, jasmine */
+
+describe('PasswordRecoveryModalController', function () {
+  beforeEach(module('myApp.controllers'))
+
+  beforeEach(function () {
+    this.pwm = {
+      pwmError: null,
+      recover: function () {
+        var pwmError = this.pwmError
+        return {
+          then: function (action, error) {
+            if (!pwmError) {
+              action({})
+            } else {
+              error(pwmError)
+            }
+          }
+        }
+      }
+    }
+
+    this.errs = { alert: jasmine.createSpy('alert') }
+    this.mi = {
+      close: jasmine.createSpy('close'),
+      dismiss: jasmine.createSpy('dismiss')
+    }
+
+    var pwm = this.pwm
+    var errs = this.errs
+    var mi = this.mi
+
+    inject(function (_$controller_, _$rootScope_, ___) {
+      this.$controller = _$controller_
+      var $scope = _$rootScope_.$new()
+      $scope.recovery = {}
+      this.$scope = $scope
+      this.$controller('PasswordRecoveryModalController', {
+        $scope: $scope,
+        $q: {},
+        _: ___,
+        PasswordManager: pwm,
+        MtpApiManager: {},
+        ErrorService: errs,
+        $modalInstance: mi
+      })
+    })
+  })
+
+  // tests
+
+  it('can handle a successful password change', function (done) {
+    this.$scope.checkCode()
+
+    expect(this.$scope.recovery.updating).toBe(true)
+    expect(this.errs.alert).toHaveBeenCalledWith('Password deactivated', 'You have disabled Two-Step Verification.')
+    expect(this.mi.close).toHaveBeenCalled()
+    done()
+  })
+
+  describe('when an error occurs', function () {
+    beforeEach(function () {
+      this.pwm.pwmError = {}
+    })
+
+    it('cancels the recovery', function (done) {
+      this.$scope.checkCode()
+
+      expect(this.$scope.recovery.updating).not.toBeDefined()
+      expect(this.errs.alert).not.toHaveBeenCalled()
+      expect(this.mi.close).not.toHaveBeenCalled()
+      done()
+    })
+
+    it('can handle the error for an empty code', function (done) {
+      this.pwm.pwmError.type = 'CODE_EMPTY'
+      this.$scope.checkCode()
+
+      expect(this.$scope.recovery.error_field).toEqual('code')
+      done()
+    })
+
+    it('can handle the error for an invalid code', function (done) {
+      this.pwm.pwmError.type = 'CODE_INVALID'
+      this.$scope.checkCode()
+
+      expect(this.$scope.recovery.error_field).toEqual('code')
+      done()
+    })
+
+    it('can handle the error for an empty password', function (done) {
+      this.pwm.pwmError.type = 'PASSWORD_EMPTY'
+      this.$scope.checkCode()
+
+      expect(this.mi.dismiss).toHaveBeenCalled()
+      done()
+    })
+
+    it('can handle the error for the unavailability of the recovery', function (done) {
+      this.pwm.pwmError.type = 'PASSWORD_RECOVERY_NA'
+      this.$scope.checkCode()
+
+      expect(this.mi.dismiss).toHaveBeenCalled()
+      done()
+    })
+
+    it('can handle the error for an expired recovery', function (done) {
+      this.pwm.pwmError.type = 'PASSWORD_RECOVERY_EXPIRED'
+      this.$scope.checkCode()
+
+      expect(this.mi.dismiss).toHaveBeenCalled()
+      done()
+    })
+  })
+})

--- a/test/unit/controllers/PasswordRecoveryModalControllerSpec.js
+++ b/test/unit/controllers/PasswordRecoveryModalControllerSpec.js
@@ -5,31 +5,34 @@ describe('PasswordRecoveryModalController', function () {
   beforeEach(module('myApp.controllers'))
 
   beforeEach(function () {
-    this.pwm = {
-      pwmError: null,
+    this.PasswordManager = {
+      errorField: null,
       recover: function () {
-        var pwmError = this.pwmError
+        return this
+      },
+      then: function (callback, error) {
+        if (!this.errorField) {
+          callback({})
+        } else {
+          error(this.errorField)
+        }
         return {
-          then: function (action, error) {
-            if (!pwmError) {
-              action({})
-            } else {
-              error(pwmError)
-            }
+          finally: function (final) {
+            final()
           }
         }
       }
     }
 
-    this.errs = { alert: jasmine.createSpy('alert') }
-    this.mi = {
+    this.ErrorService = { alert: jasmine.createSpy('alert') }
+    this.modalInstance = {
       close: jasmine.createSpy('close'),
       dismiss: jasmine.createSpy('dismiss')
     }
 
-    var pwm = this.pwm
-    var errs = this.errs
-    var mi = this.mi
+    var PasswordManager = this.PasswordManager
+    var ErrorService = this.ErrorService
+    var modalInstance = this.modalInstance
 
     inject(function (_$controller_, _$rootScope_, ___) {
       this.$controller = _$controller_
@@ -40,41 +43,39 @@ describe('PasswordRecoveryModalController', function () {
         $scope: $scope,
         $q: {},
         _: ___,
-        PasswordManager: pwm,
+        PasswordManager: PasswordManager,
         MtpApiManager: {},
-        ErrorService: errs,
-        $modalInstance: mi
+        ErrorService: ErrorService,
+        $modalInstance: modalInstance
       })
     })
   })
-
-  // tests
 
   it('can handle a successful password change', function (done) {
     this.$scope.checkCode()
 
     expect(this.$scope.recovery.updating).toBe(true)
-    expect(this.errs.alert).toHaveBeenCalledWith('Password deactivated', 'You have disabled Two-Step Verification.')
-    expect(this.mi.close).toHaveBeenCalled()
+    expect(this.ErrorService.alert).toHaveBeenCalledWith('Password deactivated', 'You have disabled Two-Step Verification.')
+    expect(this.modalInstance.close).toHaveBeenCalled()
     done()
   })
 
   describe('when an error occurs', function () {
     beforeEach(function () {
-      this.pwm.pwmError = {}
+      this.PasswordManager.errorField = {}
     })
 
     it('cancels the recovery', function (done) {
       this.$scope.checkCode()
 
       expect(this.$scope.recovery.updating).not.toBeDefined()
-      expect(this.errs.alert).not.toHaveBeenCalled()
-      expect(this.mi.close).not.toHaveBeenCalled()
+      expect(this.ErrorService.alert).not.toHaveBeenCalled()
+      expect(this.modalInstance.close).not.toHaveBeenCalled()
       done()
     })
 
     it('can handle the error for an empty code', function (done) {
-      this.pwm.pwmError.type = 'CODE_EMPTY'
+      this.PasswordManager.errorField.type = 'CODE_EMPTY'
       this.$scope.checkCode()
 
       expect(this.$scope.recovery.error_field).toEqual('code')
@@ -82,7 +83,7 @@ describe('PasswordRecoveryModalController', function () {
     })
 
     it('can handle the error for an invalid code', function (done) {
-      this.pwm.pwmError.type = 'CODE_INVALID'
+      this.PasswordManager.errorField.type = 'CODE_INVALID'
       this.$scope.checkCode()
 
       expect(this.$scope.recovery.error_field).toEqual('code')
@@ -90,26 +91,26 @@ describe('PasswordRecoveryModalController', function () {
     })
 
     it('can handle the error for an empty password', function (done) {
-      this.pwm.pwmError.type = 'PASSWORD_EMPTY'
+      this.PasswordManager.errorField.type = 'PASSWORD_EMPTY'
       this.$scope.checkCode()
 
-      expect(this.mi.dismiss).toHaveBeenCalled()
+      expect(this.modalInstance.dismiss).toHaveBeenCalled()
       done()
     })
 
     it('can handle the error for the unavailability of the recovery', function (done) {
-      this.pwm.pwmError.type = 'PASSWORD_RECOVERY_NA'
+      this.PasswordManager.errorField.type = 'PASSWORD_RECOVERY_NA'
       this.$scope.checkCode()
 
-      expect(this.mi.dismiss).toHaveBeenCalled()
+      expect(this.modalInstance.dismiss).toHaveBeenCalled()
       done()
     })
 
     it('can handle the error for an expired recovery', function (done) {
-      this.pwm.pwmError.type = 'PASSWORD_RECOVERY_EXPIRED'
+      this.PasswordManager.errorField.type = 'PASSWORD_RECOVERY_EXPIRED'
       this.$scope.checkCode()
 
-      expect(this.mi.dismiss).toHaveBeenCalled()
+      expect(this.modalInstance.dismiss).toHaveBeenCalled()
       done()
     })
   })

--- a/test/unit/controllers/ProfileEditModalControllerSpec.js
+++ b/test/unit/controllers/ProfileEditModalControllerSpec.js
@@ -5,7 +5,7 @@ describe('ProfileEditModalController', function () {
   beforeEach(module('myApp.controllers'))
 
   beforeEach(function () {
-    var id = 534196
+    var id = 42
     this.randomID = id
 
     this.MtpApiManager = {
@@ -43,21 +43,17 @@ describe('ProfileEditModalController', function () {
       },
       saveApiUser: jasmine.createSpy('saveApiUser')
     }
-    this.modalInstance = { close: jasmine.createSpy('close') }
-
-    var MtpApiManager = this.MtpApiManager
-    var AppUsersManager = this.AppUsersManager
-    var modalInstance = this.modalInstance
+    this.$modalInstance = { close: jasmine.createSpy('close') }
 
     inject(function (_$controller_, _$rootScope_) {
       this.$controller = _$controller_
-      var $scope = _$rootScope_.$new()
-      this.$scope = $scope
+      this.$scope = _$rootScope_.$new()
+
       this.$controller('ProfileEditModalController', {
-        $scope: $scope,
-        $modalInstance: modalInstance,
-        AppUsersManager: AppUsersManager,
-        MtpApiManager: MtpApiManager
+        $scope: this.$scope,
+        $modalInstance: this.$modalInstance,
+        AppUsersManager: this.AppUsersManager,
+        MtpApiManager: this.MtpApiManager
       })
     })
   })
@@ -72,7 +68,7 @@ describe('ProfileEditModalController', function () {
     this.$scope.updateProfile()
 
     expect(this.AppUsersManager.saveApiUser).toHaveBeenCalled()
-    expect(this.modalInstance.close).toHaveBeenCalled()
+    expect(this.$modalInstance.close).toHaveBeenCalled()
     done()
   })
 
@@ -82,7 +78,7 @@ describe('ProfileEditModalController', function () {
     this.$scope.updateProfile()
 
     expect(this.AppUsersManager.saveApiUser).toHaveBeenCalled()
-    expect(this.modalInstance.close).toHaveBeenCalled()
+    expect(this.$modalInstance.close).toHaveBeenCalled()
     done()
   })
 
@@ -106,7 +102,7 @@ describe('ProfileEditModalController', function () {
     this.MtpApiManager.errorField = {type: 'NAME_NOT_MODIFIED'}
     this.$scope.updateProfile()
 
-    expect(this.modalInstance.close).toHaveBeenCalled()
+    expect(this.$modalInstance.close).toHaveBeenCalled()
     done()
   })
 })

--- a/test/unit/controllers/ProfileEditModalControllerSpec.js
+++ b/test/unit/controllers/ProfileEditModalControllerSpec.js
@@ -1,0 +1,122 @@
+'use strict'
+/* global describe, it, inject, expect, beforeEach, jasmine */
+
+describe('ProfileEditModalController', function () {
+  beforeEach(module('myApp.controllers'))
+
+  beforeEach(function () {
+    var id = 534196
+    this.randomID = id
+
+    this.API = {
+      apiError: null,
+      getUserID: function () {
+        return {
+          then: function (f) {
+            f(id)
+          }
+        }
+      },
+      invokeApi: function (action, params) {
+        var fin = {
+          finally: function (f) {
+            f()
+          }
+        }
+        if (!this.apiError) {
+          return {
+            then: function (action, error) {
+              action({})
+              return fin
+            }
+          }
+        } else {
+          var err = this.apiError
+          return {
+            then: function (action, error) {
+              error(err)
+              return fin
+            }
+          }
+        }
+      }
+    }
+
+    this.aum = {
+      getUser: function (userId) {
+        return {
+          first_name: 'John',
+          last_name: 'Doe'
+        }
+      },
+      saveApiUser: jasmine.createSpy('saveApiUser')
+    }
+    this.mi = { close: jasmine.createSpy('close') }
+
+    var api = this.API
+    var aum = this.aum
+    var mi = this.mi
+
+    inject(function (_$controller_, _$rootScope_) {
+      this.$controller = _$controller_
+      var $scope = _$rootScope_.$new()
+      this.$scope = $scope
+      this.$controller('ProfileEditModalController', {
+        $scope: $scope,
+        $modalInstance: mi,
+        AppUsersManager: aum,
+        MtpApiManager: api
+      })
+    })
+  })
+
+  // tests
+
+  it('should initiate the right scope', function (done) {
+    expect(this.$scope.profile).toEqual({first_name: 'John', last_name: 'Doe'})
+    expect(this.$scope.error).toEqual({})
+    done()
+  })
+
+  it('can send a successful profile update request', function (done) {
+    this.$scope.updateProfile()
+
+    expect(this.aum.saveApiUser).toHaveBeenCalled()
+    expect(this.mi.close).toHaveBeenCalled()
+    done()
+  })
+
+  it('can handle empty name/surname', function (done) {
+    delete this.$scope.profile.first_name
+    delete this.$scope.profile.last_name
+    this.$scope.updateProfile()
+
+    expect(this.aum.saveApiUser).toHaveBeenCalled()
+    expect(this.mi.close).toHaveBeenCalled()
+    done()
+  })
+
+  it('can handle an invalid first name error', function (done) {
+    this.API.apiError = {type: 'FIRSTNAME_INVALID'}
+    this.$scope.updateProfile()
+
+    expect(this.$scope.error.field).toEqual('first_name')
+    done()
+  })
+
+  it('can handle an invalid last name error', function (done) {
+    this.API.apiError = {type: 'LASTNAME_INVALID'}
+    this.$scope.updateProfile()
+
+    expect(this.$scope.error.field).toEqual('last_name')
+    done()
+  })
+
+  it('can handle an unmodified name error', function (done) {
+    this.API.apiError = {type: 'NAME_NOT_MODIFIED'}
+    this.$scope.updateProfile()
+
+    expect(this.mi.close).toHaveBeenCalled()
+    done()
+  })
+})

--- a/test/unit/controllers/UsernameEditModalControllerSpec.js
+++ b/test/unit/controllers/UsernameEditModalControllerSpec.js
@@ -39,19 +39,15 @@ describe('UsernameEditModalController', function () {
       close: jasmine.createSpy('close')
     }
 
-    var MtpApiManager = this.MtpApiManager
-    var AppUsersManager = this.AppUsersManager
-    var modalInstance = this.modalInstance
-
     inject(function (_$controller_, _$rootScope_) {
       this.$controller = _$controller_
-      var $scope = _$rootScope_.$new()
-      this.$scope = $scope
+      this.$scope = _$rootScope_.$new()
+
       this.$controller('UsernameEditModalController', {
-        $scope: $scope,
-        $modalInstance: modalInstance,
-        AppUsersManager: AppUsersManager,
-        MtpApiManager: MtpApiManager
+        $scope: this.$scope,
+        $modalInstance: this.modalInstance,
+        AppUsersManager: this.AppUsersManager,
+        MtpApiManager: this.MtpApiManager
       })
     })
   })

--- a/test/unit/controllers/UsernameEditModalControllerSpec.js
+++ b/test/unit/controllers/UsernameEditModalControllerSpec.js
@@ -5,7 +5,7 @@ describe('UsernameEditModalController', function () {
   beforeEach(module('myApp.controllers'))
 
   beforeEach(function () {
-    this.mam = {
+    this.MtpApiManager = {
       errorField: false,
       isValid: true,
       invokeApi: function () {
@@ -14,34 +14,34 @@ describe('UsernameEditModalController', function () {
       getUserID: function () {
         return this
       },
-      then: function (action, error) {
+      then: function (callback, error) {
         if (!this.errorField) {
-          action(this.isValid)
+          callback(this.isValid)
         } else {
           error(this.errorField)
         }
         return {
-          finally: function (f) {
-            f()
+          finally: function (final) {
+            final()
           }
         }
       }
     }
 
-    this.aum = {
+    this.AppUsersManager = {
       saveApiUser: jasmine.createSpy('saveApiUser'),
       getUser: function (id) {
         return { username: 'bob' }
       }
     }
 
-    this.mi = {
+    this.modalInstance = {
       close: jasmine.createSpy('close')
     }
 
-    var mam = this.mam
-    var aum = this.aum
-    var mi = this.mi
+    var MtpApiManager = this.MtpApiManager
+    var AppUsersManager = this.AppUsersManager
+    var modalInstance = this.modalInstance
 
     inject(function (_$controller_, _$rootScope_) {
       this.$controller = _$controller_
@@ -49,14 +49,12 @@ describe('UsernameEditModalController', function () {
       this.$scope = $scope
       this.$controller('UsernameEditModalController', {
         $scope: $scope,
-        $modalInstance: mi,
-        AppUsersManager: aum,
-        MtpApiManager: mam
+        $modalInstance: modalInstance,
+        AppUsersManager: AppUsersManager,
+        MtpApiManager: MtpApiManager
       })
     })
   })
-
-  // tests
 
   it('constructs the information for the modal', function (done) {
     var expected = {
@@ -71,8 +69,8 @@ describe('UsernameEditModalController', function () {
     this.$scope.updateUsername()
 
     expect(this.$scope.checked).toEqual({})
-    expect(this.aum.saveApiUser).toHaveBeenCalled()
-    expect(this.mi.close).toHaveBeenCalled()
+    expect(this.AppUsersManager.saveApiUser).toHaveBeenCalled()
+    expect(this.modalInstance.close).toHaveBeenCalled()
     done()
   })
 
@@ -81,18 +79,18 @@ describe('UsernameEditModalController', function () {
     this.$scope.updateUsername()
 
     expect(this.$scope.checked).toEqual({})
-    expect(this.aum.saveApiUser).toHaveBeenCalled()
-    expect(this.mi.close).toHaveBeenCalled()
+    expect(this.AppUsersManager.saveApiUser).toHaveBeenCalled()
+    expect(this.modalInstance.close).toHaveBeenCalled()
     done()
   })
 
   it('can handle an unsuccessful update of an unmodified username', function (done) {
-    this.mam.errorField = { type: 'USERNAME_NOT_MODIFIED' }
+    this.MtpApiManager.errorField = { type: 'USERNAME_NOT_MODIFIED' }
     this.$scope.updateUsername()
 
     expect(this.$scope.checked).not.toBeDefined()
-    expect(this.aum.saveApiUser).not.toHaveBeenCalled()
-    expect(this.mi.close).toHaveBeenCalled()
+    expect(this.AppUsersManager.saveApiUser).not.toHaveBeenCalled()
+    expect(this.modalInstance.close).toHaveBeenCalled()
     done()
   })
 
@@ -123,7 +121,7 @@ describe('UsernameEditModalController', function () {
     done()
   })
 
-  it('doesn\'t check anything when the name isn\'t changed', function (done) {
+  it('does not check anything when the name is not changed', function (done) {
     this.$scope.$digest()
     delete this.$scope.checked.success
     this.$scope.$digest()
@@ -133,7 +131,7 @@ describe('UsernameEditModalController', function () {
   })
 
   it('can check an invalid username submission', function (done) {
-    this.mam.isValid = false
+    this.MtpApiManager.isValid = false
     this.$scope.$digest()
     var expected = true
 
@@ -142,7 +140,7 @@ describe('UsernameEditModalController', function () {
   })
 
   it('can check an invalid username submission 2', function (done) {
-    this.mam.errorField = { type: 'USERNAME_INVALID' }
+    this.MtpApiManager.errorField = { type: 'USERNAME_INVALID' }
     this.$scope.$digest()
     var expected = true
 

--- a/test/unit/controllers/UsernameEditModalControllerSpec.js
+++ b/test/unit/controllers/UsernameEditModalControllerSpec.js
@@ -1,0 +1,152 @@
+'use strict'
+/* global describe, it, inject, expect, beforeEach, jasmine */
+
+describe('UsernameEditModalController', function () {
+  beforeEach(module('myApp.controllers'))
+
+  beforeEach(function () {
+    this.mam = {
+      errorField: false,
+      isValid: true,
+      invokeApi: function () {
+        return this
+      },
+      getUserID: function () {
+        return this
+      },
+      then: function (action, error) {
+        if (!this.errorField) {
+          action(this.isValid)
+        } else {
+          error(this.errorField)
+        }
+        return {
+          finally: function (f) {
+            f()
+          }
+        }
+      }
+    }
+
+    this.aum = {
+      saveApiUser: jasmine.createSpy('saveApiUser'),
+      getUser: function (id) {
+        return { username: 'bob' }
+      }
+    }
+
+    this.mi = {
+      close: jasmine.createSpy('close')
+    }
+
+    var mam = this.mam
+    var aum = this.aum
+    var mi = this.mi
+
+    inject(function (_$controller_, _$rootScope_) {
+      this.$controller = _$controller_
+      var $scope = _$rootScope_.$new()
+      this.$scope = $scope
+      this.$controller('UsernameEditModalController', {
+        $scope: $scope,
+        $modalInstance: mi,
+        AppUsersManager: aum,
+        MtpApiManager: mam
+      })
+    })
+  })
+
+  // tests
+
+  it('constructs the information for the modal', function (done) {
+    var expected = {
+      username: 'bob'
+    }
+    expect(this.$scope.profile).toEqual(expected)
+    expect(this.$scope.error).toEqual({})
+    done()
+  })
+
+  it('can handle a successful update of the username', function (done) {
+    this.$scope.updateUsername()
+
+    expect(this.$scope.checked).toEqual({})
+    expect(this.aum.saveApiUser).toHaveBeenCalled()
+    expect(this.mi.close).toHaveBeenCalled()
+    done()
+  })
+
+  it('can handle a successful update of an empty/undefined username', function (done) {
+    delete this.$scope.profile.username
+    this.$scope.updateUsername()
+
+    expect(this.$scope.checked).toEqual({})
+    expect(this.aum.saveApiUser).toHaveBeenCalled()
+    expect(this.mi.close).toHaveBeenCalled()
+    done()
+  })
+
+  it('can handle an unsuccessful update of an unmodified username', function (done) {
+    this.mam.errorField = { type: 'USERNAME_NOT_MODIFIED' }
+    this.$scope.updateUsername()
+
+    expect(this.$scope.checked).not.toBeDefined()
+    expect(this.aum.saveApiUser).not.toHaveBeenCalled()
+    expect(this.mi.close).toHaveBeenCalled()
+    done()
+  })
+
+  it('can check an empty username on change', function (done) {
+    this.$scope.profile.username = {}
+    var expected = {}
+
+    this.$scope.$digest()
+    expect(this.$scope.checked).toEqual(expected)
+    done()
+  })
+
+  it('can check an empty string as username', function (done) {
+    this.$scope.profile.username = ''
+    var expected = {}
+
+    this.$scope.$digest()
+    expect(this.$scope.checked).toEqual(expected)
+    done()
+  })
+
+  it('can check the initial username', function (done) {
+    // Previous username is expected to be valid
+    this.$scope.$digest()
+    var expected = true
+
+    expect(this.$scope.checked.success).toBe(expected)
+    done()
+  })
+
+  it('doesn\'t check anything when the name isn\'t changed', function (done) {
+    this.$scope.$digest()
+    delete this.$scope.checked.success
+    this.$scope.$digest()
+
+    expect(this.$scope.checked.success).not.toBeDefined()
+    done()
+  })
+
+  it('can check an invalid username submission', function (done) {
+    this.mam.isValid = false
+    this.$scope.$digest()
+    var expected = true
+
+    expect(this.$scope.checked.error).toBe(expected)
+    done()
+  })
+
+  it('can check an invalid username submission 2', function (done) {
+    this.mam.errorField = { type: 'USERNAME_INVALID' }
+    this.$scope.$digest()
+    var expected = true
+
+    expect(this.$scope.checked.error).toBe(expected)
+    done()
+  })
+})


### PR DESCRIPTION
Relates to #1354 
This PR adds test to improve the test coverage of controller.js to over 10%
The following controllers have been tested:

-  CountrySelectModalController
- ImportContactModalController
- ProfileEditModalController
- PasswordRecoveryModalController
- UsernameEditModalController

UsernameEditModalController misses tests for two scenarios:

- UsernameEditModalController, when the username changes before the check returns feedback, dismisses the positive feedback
- UsernameEditModalController, when the username changes before the check returns feedback, dismisses the error

The test coverage will change as follows:

|             | % Statements | % Branch | % Functions | % Lines |
|:-----------:|:------------:|:--------:|:-------------:|:---------:|
|  Currently  |      6.99   |    1.29  |    6.45     |   7.02 | 
| After Merge |   10.71     |     4.73 |    11.47 |     10.75  |

In addition, a small style cleanup has been done in the controller.js
