### PR TITLE
Fix problem with 'ь' in search

### DIFF
--- a/app/js/lib/utils.js
+++ b/app/js/lib/utils.js
@@ -477,7 +477,8 @@ function versionCompare (ver1, ver2) {
     var hasTag = text.charAt(0) == '%'
     text = text.replace(badCharsRe, ' ').replace(trimRe, '')
     text = text.replace(/[^A-Za-z0-9]/g, function (ch) {
-      return Config.LatinizeMap[ch] || ch
+      var latinizeCh = Config.LatinizeMap[ch]
+      return latinizeCh !== undefined ? latinizeCh : ch
     })
     text = text.toLowerCase()
     if (hasTag) {


### PR DESCRIPTION
Config.LatinizeMap have rule for 'ь' but it is not applied.

Now you can't find russian names with 'ь'. Latinize works incorrect 'илья' translates to 'ilьya'. I found problem with empty string and operator ||.