### PR TITLE
 Fixes #1560

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -190,7 +190,9 @@ function writeServiceWorkerFile (rootDir, handleFetch, callback) {
     staticFileGlobs: fileGlobs,
     stripPrefix: './' + rootDir + '/',
     importScripts: ['js/lib/push_worker.js'],
-    verbose: true
+    verbose: true,
+    maximumFileSizeToCacheInBytes: 3004152, // about 3MB, default is "2097152" 2MB,
+    navigateFallback: "index.html",
   }
   swPrecache.write(path.join(rootDir, 'service_worker.js'), config, callback)
 }


### PR DESCRIPTION
This fixes a caching issue where the app.js files is not cached because it exceeds the maximum file size of sw-precache. 

The `navigateFallback` also will handle all HTML document request which are not directly covered by the cache.