### PR TITLE
Align reply button row. Fix #1616

### DIFF
--- a/app/less/app.less
+++ b/app/less/app.less
@@ -2421,6 +2421,7 @@ a.im_message_fwd_photo {
 .reply_markup_button_wrap {
   display: inline-block;
   padding: 0 4px;
+  vertical-align: middle;
 }
 .reply_markup_button {
   color: #3a6d99;


### PR DESCRIPTION
Looks like the problem was in `a` and `button` being siblings and aligning differently by default.

An example message for checking PR: https://t.me/webogram_bug_buttons_demo/3.

![image](https://user-images.githubusercontent.com/8142557/35629995-2cdf3fc2-06b1-11e8-9d57-77f591c6eb84.png)
