### PR TITLE
Making colors consistent with other clients

### DIFF
--- a/app/js/services.js
+++ b/app/js/services.js
@@ -122,7 +122,7 @@ angular.module('myApp.services', ['myApp.i18n', 'izhukov.utils'])
         apiUser.rPhone = $filter('phoneNumber')(apiUser.phone)
       }
 
-      apiUser.num = (Math.abs(userID) % 8) + 1
+      apiUser.num = Math.abs(userID % 7) + 1
 
       if (apiUser.first_name) {
         apiUser.rFirstName = RichTextProcessor.wrapRichText(apiUser.first_name, {noLinks: true, noLinebreaks: true})

--- a/app/less/lib/mixins.less
+++ b/app/less/lib/mixins.less
@@ -1,20 +1,18 @@
-@user_colors:   '#8365ab',
+@user_colors:   '#b7635d',
+                '#c07844',
+                '#8365ab',
                 '#539e4f',
-                '#ae9661',
-                '#4979a3',
-                '#b7635d',
-                '#b3577a',
                 '#5397b4',
-                '#c07844';
+                '#4979a3',
+                '#b3577a';
 
-@user_bgcolors: '#cc90e2',
+@user_bgcolors: '#e57979',
+                '#fba76f',
+                '#cc90e2',
                 '#80d066',
-                '#ecd074',
-                '#6fb1e4',
-                '#e57979',
-                '#f98bae',
                 '#73cdd0',
-                '#fba76f';
+                '#6fb1e4',
+                '#f98bae';
 
 .generate_user(@arr, @isColor) {
     .-(@i: 1) when (@i <= length(@arr)) {


### PR DESCRIPTION
When I use other clients (Telegram for Android, Telegram Swift and Telegram Desktop), the colors assigned to users are consistent among them (not exactly the same but violet remains violet, green remains green etc.). This PR tries to bring color selection from Android client here.

Here is an algorithm to choose a color from user id:
https://github.com/DrKLO/Telegram/blob/d073b80063c568f31d81cc88c927b47c01a1dbf4/TMessagesProj/src/main/java/org/telegram/ui/Components/AvatarDrawable.java#L77-L82

Here are the lists of colors:
https://github.com/DrKLO/Telegram/blob/d073b80063c568f31d81cc88c927b47c01a1dbf4/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java#L644-L650

The original colors from webogram master are reused, just rearranged to match other clients, yellow had to be removed 😞. 