### PR TITLE
Enrich package.json (and Readme) to avoid gulp global install

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,13 @@ The app is based on the AngularJS JavaScript framework, and written in pure Java
 The project repository is based on angularjs-seed and includes gulp tasks, so it's easy to launch the app locally on your desktop.
 Install [node.js](http://nodejs.org/).
 
+Install dependancies with:
+
 ```lang=bash
 npm install
 ```
 
-Optionnaly, run the following commands in the project directory to install gulp globally:
+Optionaly, run the following commands in the project directory to install gulp globally:
 
 ```lang=bash
 sudo npm install -g gulp

--- a/README.md
+++ b/README.md
@@ -58,11 +58,14 @@ The app is based on the AngularJS JavaScript framework, and written in pure Java
 The project repository is based on angularjs-seed and includes gulp tasks, so it's easy to launch the app locally on your desktop.
 Install [node.js](http://nodejs.org/).
 
+```lang=bash
+npm install
+```
+
 Optionnaly, run the following commands in the project directory to install gulp globally:
 
 ```lang=bash
 sudo npm install -g gulp
-npm install
 ```
 
 This will install all the needed dependencies.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The app is based on the AngularJS JavaScript framework, and written in pure Java
 The project repository is based on angularjs-seed and includes gulp tasks, so it's easy to launch the app locally on your desktop.
 Install [node.js](http://nodejs.org/).
 
-Install dependancies with:
+Install dependencies with:
 
 ```lang=bash
 npm install

--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ The app is based on the AngularJS JavaScript framework, and written in pure Java
 
 
 The project repository is based on angularjs-seed and includes gulp tasks, so it's easy to launch the app locally on your desktop.
-Install [node.js](http://nodejs.org/) and run the following commands in the project directory
+Install [node.js](http://nodejs.org/).
 
-```
+Optionnaly, run the following commands in the project directory to install gulp globally:
+
+```lang=bash
 sudo npm install -g gulp
 npm install
 ```
@@ -69,7 +71,7 @@ This will install all the needed dependencies.
 #### Running web-server
 
 
-Just run `gulp watch` to start the web server and the livereload task.
+Just run `npm start` (`gulp watch`) to start the web server and the livereload task.
 Open http://localhost:8000/app/index.html in your browser.
 
 
@@ -78,18 +80,18 @@ Open http://localhost:8000/app/index.html in your browser.
 
 To run this application in Google Chrome as a packaged app, open this URL (in Chrome): `chrome://extensions/`, then tick "Developer mode" and press "Load unpacked extension...". Select the downloaded `app` folder and Webogram should appear in the list.
 
-Run `gulp watch` to watch for file changes and automatically rebuild the app.
+Run `npm start` (`gulp watch`) to watch for file changes and automatically rebuild the app.
 
 
 #### Running as Firefox OS App
 
 To run this application in Firefox as a packaged app, open "Menu" -> "Developer" -> "WebIDE" (or hit `Shift + F8`). Choose "Open packaged app" from the Project menu and select the `app` folder.
 
-Run `gulp watch` to watch for file changes and automatically rebuild the app.
+Run `npm start` (`gulp watch`) to watch for file changes and automatically rebuild the app.
 
 #### Running in production
 
-Run `gulp clean`, then `gulp publish` to build the minimized production version of the app. Copy `dist` folder contents to your web server. Don't forget to set `X-Frame-Options SAMEORIGIN` header ([docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options)).
+Run `npm run clean` (`gulp clean`), then `npm run publish` (`gulp publish`) to build the minimized production version of the app. Copy `dist` folder contents to your web server. Don't forget to set `X-Frame-Options SAMEORIGIN` header ([docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options)).
 
 
 ### Third party libraries

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "show": true
   },
   "scripts": {
+    "clean": "gulp clean",
     "start": "gulp watch",
-    "test": "gulp test"
+    "test": "gulp test",
+    "build": "gulp publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Not everybody want to have a global install of gulp, when it is not necessary.

So I made proxy scripts in the package.json and enrich the readme accordingly.