### PR TITLE
Add link to the URL in the unsafe url popup dialog

### DIFF
--- a/app/partials/desktop/confirm_modal.html
+++ b/app/partials/desktop/confirm_modal.html
@@ -80,7 +80,7 @@
       <div ng-switch-when="CHANNEL_LEAVE" my-i18n="confirm_modal_leave_channel_md"></div>
       <div ng-switch-when="MEGAGROUP_LEAVE" my-i18n="confirm_modal_leave_group_md"></div>
       <div ng-switch-when="JUMP_EXT_URL" my-i18n="confirm_modal_jump_ext_url_md" class="confirm_modal_extlink_jump">
-        <my-i18n-param name="url"><strong ng-bind="url"></strong></my-i18n-param>
+        <my-i18n-param name="url"><a ng-href="{{url}}" target="_blank"><strong ng-bind="url"></strong></a></my-i18n-param>
       </div>
       <div ng-switch-when="SUPERGROUP_MIGRATE" my-i18n="confirm_modal_migrate_supergroup_md"></div>
       <div ng-switch-when="BOT_ACCESS_PHONE" my-i18n="confirm_modal_bot_access_phone"></div>


### PR DESCRIPTION
This makes it a normal link and enables the user to middle-click,
right-click, copy the link destination etc.

This resolves #1715.