### PR TITLE
Fix text overflow issue for German and other languages

### DIFF
--- a/app/less/desktop.less
+++ b/app/less/desktop.less
@@ -289,7 +289,6 @@
 
   &_dropdown {
     .dropdown-menu {
-      max-width: 100%;
       border-radius: 0;
       padding: 9px 0;
 


### PR DESCRIPTION
Some languages have long string for i18n (e.g. German). This change allows dropdown menu to take more place for better displaying of content.

Before:
![1](https://user-images.githubusercontent.com/123756/47173214-c6e91600-d30d-11e8-8bb8-22bdc71c79a9.png)

After:
![2](https://user-images.githubusercontent.com/123756/47173232-d2d4d800-d30d-11e8-889f-ae5b2b443d1c.png)

