### PR TITLE
Increase text contrast of im_dialog_badge_muted

### DIFF
--- a/app/less/app.less
+++ b/app/less/app.less
@@ -1386,7 +1386,7 @@ a.im_dialog_selected {
     display: none;
   }
   &_muted {
-    background: #bfbfbf;
+    background: #a4a4a4;
   }
 }
 


### PR DESCRIPTION
The current background color of #bfbfbf results in a contrast
ratio of 1.84, which is subpar. Changing the background color
to #a4a4a4 brings the contrast ratio up to 2.49, which is much
more legible.

The contrast ratios were tested using https://contrastchecker.com