### PR TITLE
main menu accessible for screen reader

### DIFF
--- a/app/js/locales/de-de.json
+++ b/app/js/locales/de-de.json
@@ -407,6 +407,7 @@
     "error_modal_gelocation_na": "App kann deinen aktuellen Standort nicht bestimmen",
     "error_modal_2fa_recent_confirm": "Deine vorherigen Versuche das Konto zurückzusetzen wurden durch den aktiven Nutzer abgebrochen. Bitte in 7 Tagen erneut probieren.",
     "error_modal_2fa_delayed_time_md": "Du kannst dein Konto zurücksetzen in: **{time}**",
+    "head_mainmenu": "Hauptmenü",
     "head_telegram": "Telegram",
     "head_new_group": "Neue Gruppe",
     "head_new_contact": "Neuer Kontakt",

--- a/app/js/locales/en-us.json
+++ b/app/js/locales/en-us.json
@@ -460,7 +460,7 @@
 	"error_modal_2fa_recent_confirm": "Your recent attempts to reset this account have been cancelled by its active user. Please try again in 7 days.",
 	"error_modal_2fa_delayed_time_md": "You'll be able to reset your account in: **{time}**",
 
-
+	"head_mainmenu": "Main menu",
 	"head_telegram": "Telegram",
 	"head_new_group": "New group",
 	"head_new_contact": "New contact",

--- a/app/less/app.less
+++ b/app/less/app.less
@@ -5023,4 +5023,10 @@ a.countries_modal_search_clear {
   }
 }
 
-
+.visually-hidden { /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
+  position: absolute !important;
+  height: 1px; width: 1px;
+  overflow: hidden;
+  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+  clip: rect(1px, 1px, 1px, 1px);
+}

--- a/app/partials/desktop/head.html
+++ b/app/partials/desktop/head.html
@@ -4,6 +4,7 @@
     <div class="tg_head_logo_wrap">
       <div class="tg_head_logo_dropdown dropdown" dropdown>
         <a class="tg_head_btn dropdown-toggle" dropdown-toggle>
+          <span class="visually-hidden" my-i18n="head_mainmenu"></span>
           <div class="icon-hamburger-wrap">
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>


### PR DESCRIPTION
The webogram interface has some issues regarding the accessibility for blind users, who use screen reading software. Therefore, the link at the top which is responsible for opening the main menu was not accessible at all.
To solve this, with some help of @dhtstudios, I added the visually-hidden-class and wrote some text into it, in German and English language.