### PR TITLE
Limit login max phone number length

### DIFF
--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -177,7 +177,7 @@ angular.module('myApp.controllers', ['myApp.i18n'])
       var badPhone = !fullPhone.match(/^[\d\-+\s]+$/)
       if (!badPhone) {
         fullPhone = fullPhone.replace(/\D/g, '')
-        if (fullPhone.length < 7) {
+        if (fullPhone.length < 7 || fullPhone.length > 15) {
           badPhone = true
         }
       }


### PR DESCRIPTION
In the international telephone network, the format of telephone numbers is standardized by ITU-T recommendation E.164. This code specifies that the entire number should be 15 digits or shorter.

Very long numbers look weird in the confirmation dialog

<img width="1033" alt="Screenshot 2020-03-25 at 22 02 17" src="https://user-images.githubusercontent.com/13489212/77580635-6809d200-6eed-11ea-87c5-171831a816de.png">
