### PR TITLE
Enable Russian localization

### DIFF
--- a/app/js/lib/config.js
+++ b/app/js/lib/config.js
@@ -64,7 +64,7 @@ Config.I18n = {
     , 'it-it'
     , 'nl-nl'
     , 'pt-br'
-  // ,"ru-ru"
+    , "ru-ru"
   ], // To be copied to package.json
   languages: {
     'en-us': 'English',


### PR DESCRIPTION
Russian translations are there, but globally disabled: as
https://github.com/zhukov/webogram/issues/1598 explains "Russian" is not
in the list of available languages.

The fix is simple -> just reenable "ru-ru" in Config.I18n.

Even if Russian translations are not in ideal shape (Transifex reports 86%
for Russian), it should be good to enable the localization, and then the
completeness of Russian language support could be further improved
step-by-step.

Some people prefer the WEB TG version instead of desktop app.

I'm kind of newbie when it comes to javascript, but I tested this patch
locally and it works for me - most of the UI becomes translated to
Russian after this patch.

Thanks beforehand,
Kirill

/cc @KDASOFT