### PR TITLE
unsupported media alt link based on device

### DIFF
--- a/app/js/directives.js
+++ b/app/js/directives.js
@@ -351,7 +351,10 @@ angular.module('myApp.directives', ['myApp.filters'])
         'media': '=myMessageMedia',
         'messageId': '=messageId'
       },
-      templateUrl: templateUrl('message_media')
+      templateUrl: templateUrl('message_media'),
+      link: function ($scope, element, attrs) {
+        $scope.domain = Config.Navigator.osX ? 'macos.telegram.org' : (Config.Navigator.mobile ? 'telegram.org/apps' : 'desktop.telegram.org')
+      }
     }
   })
   .directive('myMessagePhoto', function (AppPhotosManager) {

--- a/app/partials/desktop/message_media.html
+++ b/app/partials/desktop/message_media.html
@@ -10,7 +10,7 @@
 
   <div ng-switch-when="messageMediaUnsupported">
     <div class="im_message_text" my-i18n="message_attach_unsupported_desktop">
-      <my-i18n-param name="link"><a href="https://getdesktop.telegram.org" target="_blank">getdesktop.telegram.org</a></my-i18n-param>
+      <my-i18n-param name="link"><a href="https://{{domain}}" target="_blank">{{domain}}</a></my-i18n-param>
     </div>
   </div>
 


### PR DESCRIPTION
use different link for unsupported media message

sample message for animated sticker: _This message is currently not supported on Telegram Web. Try [macos.telegram.org](https://macos.telegram.org)._